### PR TITLE
Support for Multiple Teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+* [#20](https://github.com/blackjacx/assist/pull/20): Support for Multiple Teams - [@blackjacx](https://github.com/blackjacx).
 
 ## [0.0.2] - 2020-09-25
-* [#17](https://github.com/blackjacx/assist/pull/8): Implementing Screenshot Tool - [@blackjacx](https://github.com/blackjacx).
+* [#17](https://github.com/blackjacx/assist/pull/17): Implementing Screenshot Tool - [@blackjacx](https://github.com/blackjacx).
 
 ## [0.0.1] - 2020-09-16
 * [#8](https://github.com/blackjacx/assist/pull/8): Switch to JWTKit - [@blackjacx](https://github.com/blackjacx).

--- a/Sources/ASC/ASCService.swift
+++ b/Sources/ASC/ASCService.swift
@@ -12,6 +12,26 @@ struct ASCService {
 
     static let network = Network()
 
+    // MARK: - API Keys
+
+    @UserDefault("\(ProcessInfo.processId).apiKeys", defaultValue: []) static var apiKeys: [ApiKey]
+
+    static func listApiKeys() throws -> [ApiKey] {
+        return apiKeys
+    }
+
+    static func registerApiKey(_ key: ApiKey) throws {
+        apiKeys.append(key)
+    }
+
+    static func deleteApiKey(keyId: String) throws -> ApiKey {
+        guard let key = apiKeys.first(where: { keyId == $0.keyId }) else {
+            throw AscError.apiKeyNotFound(keyId)
+        }
+        apiKeys = apiKeys.filter { $0.keyId != keyId }
+        return key
+    }
+
     // MARK: - BetaGroups
 
     static func listBetaGroups(filters: [Filter] = []) throws -> [Group] {

--- a/Sources/ASC/ASCService.swift
+++ b/Sources/ASC/ASCService.swift
@@ -12,26 +12,6 @@ struct ASCService {
 
     static let network = Network()
 
-    // MARK: - API Keys
-
-    @UserDefault("\(ProcessInfo.processId).apiKeys", defaultValue: []) static var apiKeys: [ApiKey]
-
-    static func listApiKeys() throws -> [ApiKey] {
-        return apiKeys
-    }
-
-    static func registerApiKey(_ key: ApiKey) throws {
-        apiKeys.append(key)
-    }
-
-    static func deleteApiKey(keyId: String) throws -> ApiKey {
-        guard let key = apiKeys.first(where: { keyId == $0.keyId }) else {
-            throw AscError.apiKeyNotFound(keyId)
-        }
-        apiKeys = apiKeys.filter { $0.keyId != keyId }
-        return key
-    }
-
     // MARK: - BetaGroups
 
     static func listBetaGroups(filters: [Filter] = []) throws -> [Group] {

--- a/Sources/ASC/commands/ASC.swift
+++ b/Sources/ASC/commands/ASC.swift
@@ -13,7 +13,9 @@ import Core
 public final class ASC: ParsableCommand {
 
     /// Concurrent operation queue
-    public static let queue = OperationQueue()
+    static let queue = OperationQueue()
+    /// The API key chosen by the user. If only one key is registered this one is automatically used.
+    static var apiKey: ApiKey?
 
     public static var configuration = CommandConfiguration(
         // Optional abstracts and discussions are used for help output.

--- a/Sources/ASC/commands/ASC.swift
+++ b/Sources/ASC/commands/ASC.swift
@@ -22,7 +22,7 @@ public final class ASC: ParsableCommand {
         // Pass an array to `subcommands` to set up a nested tree of subcommands.
         // With language support for type-level introspection, this could be
         // provided by automatically finding nested `ParsableCommand` types.
-        subcommands: [Groups.self, Apps.self, AppStoreVersions.self, BetaTesters.self],
+        subcommands: [ApiKeys.self, Groups.self, Apps.self, AppStoreVersions.self, BetaTesters.self],
 
         // A default subcommand, when provided, is automatically selected if a
         // subcommand is not given on the command line.
@@ -36,9 +36,6 @@ struct Options: ParsableArguments {
 
     @Flag(name: .shortAndLong, help: "Activate verbose logging.")
     var verbose: Int
-
-    @Option(name: .shortAndLong, help: "Filter which is set as part of the request. See https://developer.apple.com/documentation/appstoreconnectapi for possible values.")
-    var filters: [Filter] = []
 
     mutating func validate() throws {
         // Misusing validate to set the received flag globally

--- a/Sources/ASC/commands/ASC.swift
+++ b/Sources/ASC/commands/ASC.swift
@@ -12,6 +12,9 @@ import Core
 /// The main class for the App Store Connect command line tool.
 public final class ASC: ParsableCommand {
 
+    /// Concurrent operation queue
+    public static let queue = OperationQueue()
+
     public static var configuration = CommandConfiguration(
         // Optional abstracts and discussions are used for help output.
         abstract: "A utility for accessing the App Store Connect API.",

--- a/Sources/ASC/commands/sub/ApiKeys.swift
+++ b/Sources/ASC/commands/sub/ApiKeys.swift
@@ -34,7 +34,7 @@ extension ASC.ApiKeys {
         func run() throws {
             let op = ApiKeysOperation(.list)
             ASC.queue.addOperations([op], waitUntilFinished: true)
-            print(try op.result.get())
+            try op.result.get().forEach { print($0) }
         }
     }
 
@@ -47,6 +47,9 @@ extension ASC.ApiKeys {
         @OptionGroup()
         var options: Options
 
+        @Option(name: .shortAndLong, help: "The name of the key.")
+        var name: String
+
         @Option(name: .shortAndLong, help: "The absolute path to the p8 key file.")
         var path: String
 
@@ -57,10 +60,10 @@ extension ASC.ApiKeys {
         var issuerId: String
 
         func run() throws {
-            let key = ApiKey(path: path, keyId: keyId, issuerId: issuerId)
+            let key = ApiKey(name: name, path: path, keyId: keyId, issuerId: issuerId)
             let op = ApiKeysOperation(.register(key: key))
             ASC.queue.addOperations([op], waitUntilFinished: true)
-            print(try op.result.get())
+            try op.result.get().forEach { print($0) }
         }
     }
 
@@ -79,7 +82,7 @@ extension ASC.ApiKeys {
         func run() throws {
             let op = ApiKeysOperation(.delete(keyId: keyId))
             ASC.queue.addOperations([op], waitUntilFinished: true)
-            print(try op.result.get())
+            try op.result.get().forEach { print($0) }
         }
     }
 }

--- a/Sources/ASC/commands/sub/ApiKeys.swift
+++ b/Sources/ASC/commands/sub/ApiKeys.swift
@@ -12,6 +12,7 @@ extension ASC {
 
     /// Lists, registers and deletes App Store Connect API keys locally.
     struct ApiKeys: ParsableCommand {
+
         static var configuration = CommandConfiguration(
             abstract: "Lists, registers and deletes App Store Connect API keys on your Mac.",
             subcommands: [List.self, Register.self, Delete.self],
@@ -31,8 +32,9 @@ extension ASC.ApiKeys {
         var options: Options
 
         func run() throws {
-            let apiKeys = try ASCService.listApiKeys()
-            apiKeys.forEach { print($0) }
+            let op = ApiKeysOperation(.list)
+            ASC.queue.addOperations([op], waitUntilFinished: true)
+            print(try op.result.get())
         }
     }
 
@@ -55,7 +57,10 @@ extension ASC.ApiKeys {
         var issuerId: String
 
         func run() throws {
-            try ASCService.registerApiKey(ApiKey(path: path, keyId: keyId, issuerId: issuerId))
+            let key = ApiKey(path: path, keyId: keyId, issuerId: issuerId)
+            let op = ApiKeysOperation(.register(key: key))
+            ASC.queue.addOperations([op], waitUntilFinished: true)
+            print(try op.result.get())
         }
     }
 
@@ -72,8 +77,9 @@ extension ASC.ApiKeys {
         var keyId: String
 
         func run() throws {
-            let apiKey = try ASCService.deleteApiKey(keyId: keyId)
-            print(apiKey)
+            let op = ApiKeysOperation(.delete(keyId: keyId))
+            ASC.queue.addOperations([op], waitUntilFinished: true)
+            print(try op.result.get())
         }
     }
 }

--- a/Sources/ASC/commands/sub/ApiKeys.swift
+++ b/Sources/ASC/commands/sub/ApiKeys.swift
@@ -1,0 +1,79 @@
+//
+//  RegisterApiKey.swift
+//  ASC
+//
+//  Created by Stefan Herold on 17.11.20.
+//
+
+import Foundation
+import ArgumentParser
+
+extension ASC {
+
+    /// Lists, registers and deletes App Store Connect API keys locally.
+    struct ApiKeys: ParsableCommand {
+        static var configuration = CommandConfiguration(
+            abstract: "Lists, registers and deletes App Store Connect API keys on your Mac.",
+            subcommands: [List.self, Register.self, Delete.self],
+            defaultSubcommand: List.self)
+    }
+}
+
+extension ASC.ApiKeys {
+
+    /// List locally stored App Store Connect API keys.
+    struct List: ParsableCommand {
+        static var configuration = CommandConfiguration(abstract: "List locally stored App Store Connect API keys keys.")
+
+        // The `@OptionGroup` attribute includes the flags, options, and arguments defined by another
+        // `ParsableArguments` type.
+        @OptionGroup()
+        var options: Options
+
+        func run() throws {
+            let apiKeys = try ASCService.listApiKeys()
+            apiKeys.forEach { print($0) }
+        }
+    }
+
+    /// Registers App Store Connect API keys locally.
+    struct Register: ParsableCommand {
+        static var configuration = CommandConfiguration(abstract: "Registers App Store Connect API keys locally.")
+
+        // The `@OptionGroup` attribute includes the flags, options, and arguments defined by another
+        // `ParsableArguments` type.
+        @OptionGroup()
+        var options: Options
+
+        @Option(name: .shortAndLong, help: "The absolute path to the p8 key file.")
+        var path: String
+
+        @Option(name: .shortAndLong, help: "Key key's id.")
+        var keyId: String
+
+        @Option(name: .shortAndLong, help: "The id of the key issuer.")
+        var issuerId: String
+
+        func run() throws {
+            try ASCService.registerApiKey(ApiKey(path: path, keyId: keyId, issuerId: issuerId))
+        }
+    }
+
+    /// Delete locally stored App Store Connect API keys.
+    struct Delete: ParsableCommand {
+        static var configuration = CommandConfiguration(abstract: "Delete locally stored App Store Connect API keys.")
+
+        // The `@OptionGroup` attribute includes the flags, options, and arguments defined by another
+        // `ParsableArguments` type.
+        @OptionGroup()
+        var options: Options
+
+        @Option(name: .shortAndLong, help: "Key key's id.")
+        var keyId: String
+
+        func run() throws {
+            let apiKey = try ASCService.deleteApiKey(keyId: keyId)
+            print(apiKey)
+        }
+    }
+}

--- a/Sources/ASC/commands/sub/AppStoreVersions.swift
+++ b/Sources/ASC/commands/sub/AppStoreVersions.swift
@@ -30,6 +30,9 @@ extension ASC.AppStoreVersions {
         @OptionGroup()
         var options: Options
 
+        @Option(name: .shortAndLong, help: "Filter which is set as part of the request. See https://developer.apple.com/documentation/appstoreconnectapi/list_all_app_store_versions_for_an_app for possible values.")
+        var filters: [Filter] = []
+
         @Option(name: .shortAndLong, parsing: .upToNextOption, help: "The IDs of the apps you want to get the versions from.")
         var appIds: [String] = []
 
@@ -37,7 +40,7 @@ extension ASC.AppStoreVersions {
         var attribute: String?
 
         func run() throws {
-            let result = try ASCService.listAppStoreVersions(appIds: appIds, filters: options.filters)
+            let result = try ASCService.listAppStoreVersions(appIds: appIds, filters: filters)
             for item in result {
                 if let readyForSaleVersion = item.versions.filter({ $0.attributes.appStoreState == .readyForSale }).first {
                     print("\(item.app.name.padding(toLength: 30, withPad: " ", startingAt: 0)): \(readyForSaleVersion.attributes.versionString)")

--- a/Sources/ASC/commands/sub/Apps.swift
+++ b/Sources/ASC/commands/sub/Apps.swift
@@ -31,11 +31,14 @@ extension ASC.Apps {
         @OptionGroup()
         var options: Options
 
+        @Option(name: .shortAndLong, help: "Filter which is set as part of the request. See https://developer.apple.com/documentation/appstoreconnectapi/list_apps for possible values.")
+        var filters: [Filter] = []
+
         @Argument(help: "The attribute you want to get. [name | bundleId | locale | attributes] (default: id).")
         var attribute: String?
 
         func run() throws {
-            let apps = try ASCService.listApps(filters: options.filters)
+            let apps = try ASCService.listApps(filters: filters)
             apps.out(attribute)
         }
     }

--- a/Sources/ASC/commands/sub/BetaTesters.swift
+++ b/Sources/ASC/commands/sub/BetaTesters.swift
@@ -30,11 +30,14 @@ extension ASC.BetaTesters {
         @OptionGroup()
         var options: Options
 
+        @Option(name: .shortAndLong, help: "Filter which is set as part of the request. See https://developer.apple.com/documentation/appstoreconnectapi/list_beta_testers for possible values.")
+        var filters: [Filter] = []
+
         @Argument(help: "The attribute you are interested in. [firstName | lastName | email | attributes] (default: id).")
         var attribute: String?
 
         func run() throws {
-            let result = try ASCService.listBetaTester(filters: options.filters)
+            let result = try ASCService.listBetaTester(filters: filters)
             result.out(attribute)
         }
     }

--- a/Sources/ASC/commands/sub/Groups.swift
+++ b/Sources/ASC/commands/sub/Groups.swift
@@ -30,11 +30,14 @@ extension ASC.Groups {
         @OptionGroup()
         var options: Options
 
+        @Option(name: .shortAndLong, help: "Filter which is set as part of the request. See https://developer.apple.com/documentation/appstoreconnectapi/list_beta_groups for possible values.")
+        var filters: [Filter] = []
+
         @Argument(help: "The attribute you are interested in. [firstName | lastName | email | attributes] (default: id).")
         var attribute: String?
 
         func run() throws {
-            let groups = try ASCService.listBetaGroups(filters: options.filters)
+            let groups = try ASCService.listBetaGroups(filters: filters)
             groups.out(attribute)
         }
     }

--- a/Sources/ASC/models/ApiKey.swift
+++ b/Sources/ASC/models/ApiKey.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct ApiKey: Codable {
+    var name: String
     var path: String
     var keyId: String
     var issuerId: String

--- a/Sources/ASC/models/ApiKey.swift
+++ b/Sources/ASC/models/ApiKey.swift
@@ -1,0 +1,14 @@
+//
+//  ApiKey.swift
+//  
+//
+//  Created by Stefan Herold on 17.11.20.
+//
+
+import Foundation
+
+struct ApiKey: Codable {
+    var path: String
+    var keyId: String
+    var issuerId: String
+}

--- a/Sources/ASC/models/enums/AscError.swift
+++ b/Sources/ASC/models/enums/AscError.swift
@@ -10,5 +10,6 @@ import Foundation
 enum AscError: Error {
     case noDataProvided(_ type: String)
     case noUserFound(_ email: String)
+    case apiKeyNotFound(_ keyId: String)
     case requestFailed(underlyingErrors: [Error])
 }

--- a/Sources/ASC/models/enums/AscError.swift
+++ b/Sources/ASC/models/enums/AscError.swift
@@ -10,6 +10,8 @@ import Foundation
 enum AscError: Error {
     case noDataProvided(_ type: String)
     case noUserFound(_ email: String)
+    case noApiKeysSpecified
+    case invalidInput(_ message: String)
     case apiKeyNotFound(_ keyId: String)
     case requestFailed(underlyingErrors: [Error])
 }

--- a/Sources/ASC/service/ApiKeysOperation.swift
+++ b/Sources/ASC/service/ApiKeysOperation.swift
@@ -1,0 +1,53 @@
+//
+//  ApiKeysOperation.swift
+//  ASC
+//
+//  Created by Stefan Herold on 18.11.20.
+//
+
+import Foundation
+import Core
+
+final class ApiKeysOperation: AsyncOperation {
+
+    enum SubCommand {
+        case list
+        case register(key: ApiKey)
+        case delete(keyId: String)
+    }
+
+    /// Collection of registered API keys
+    @UserDefault("\(ProcessInfo.processId).apiKeys", defaultValue: []) private static var apiKeys: [ApiKey]
+
+    var result: Result<[ApiKey], AscError>!
+
+    private let subcommand: SubCommand
+
+    init(_ subcommand: SubCommand) {
+        self.subcommand = subcommand
+    }
+
+    override func main() {
+
+        defer {
+            self.state = .finished
+        }
+
+        switch subcommand {
+        case .list:
+            result = .success(Self.apiKeys)
+
+        case .register(let key):
+            Self.apiKeys.append(key)
+            result = .success([key])
+
+        case .delete(let keyId):
+            guard let key = Self.apiKeys.first(where: { keyId == $0.keyId }) else {
+                result = .failure(.apiKeyNotFound(keyId))
+                return
+            }
+            Self.apiKeys = Self.apiKeys.filter { $0.keyId != keyId }
+            result = .success([key])
+        }
+    }
+}

--- a/Sources/Core/AsyncOperation.swift
+++ b/Sources/Core/AsyncOperation.swift
@@ -1,0 +1,64 @@
+//
+//  AsyncOperation.swift
+//  ASC
+//
+//  Created by Stefan Herold on 18.11.20.
+//
+
+import Foundation
+
+/// Operation subclass that can be used as base for any async operation. Just subclass this AsyncOperation, execute
+/// your async task and set state = .finished when finished. Doing so enables you to extract any async task into its
+/// own operation object and just add the operation to an OperationQueue. See how ReverseGeocodeOperation is
+/// implemented and used to get an idea.
+/// - https://withintent.com/blog/basics-of-operations-and-operation-queues-in-ios/
+/// - https://www.avanderlee.com/swift/asynchronous-operations/
+/// - https://gist.github.com/Sorix/57bc3295dc001434fe08acbb053ed2bc
+/// - https://www.raywenderlich.com/5293-operation-and-operationqueue-tutorial-in-swift
+/// - https://aplus.rs/2018/asynchronous-operation/
+open class AsyncOperation: Operation {
+
+    public enum State: String {
+        case ready, executing, finished
+
+        fileprivate var keyPath: String {
+            "is" + rawValue.capitalized
+        }
+    }
+
+    private let stateQueue = DispatchQueue(label: "AsyncOperation State Queue", attributes: .concurrent)
+
+    /// Non thread-safe state storage, use only with locks
+    private var stateStore: State = .ready
+
+    /// Thread-safe computed state value
+    public var state: State {
+        get {
+            stateQueue.sync { stateStore }
+        }
+        set {
+            let oldValue = state
+            willChangeValue(forKey: state.keyPath)
+            willChangeValue(forKey: newValue.keyPath)
+            stateQueue.sync(flags: .barrier) {
+                stateStore = newValue
+            }
+            didChangeValue(forKey: state.keyPath)
+            didChangeValue(forKey: oldValue.keyPath)
+        }
+    }
+}
+
+extension AsyncOperation {
+
+    public override var isAsynchronous: Bool { true }
+    public override var isExecuting: Bool { state == .executing }
+    public override var isFinished: Bool { state == .finished }
+
+    public override func start() {
+
+        guard !isCancelled else { state = .finished; return }
+        state = .executing
+        main()
+    }
+}

--- a/Sources/Core/AsyncOperation.swift
+++ b/Sources/Core/AsyncOperation.swift
@@ -26,6 +26,10 @@ open class AsyncOperation: Operation {
         }
     }
 
+    public override var isAsynchronous: Bool { true }
+    public override var isExecuting: Bool { state == .executing }
+    public override var isFinished: Bool { state == .finished }
+
     private let stateQueue = DispatchQueue(label: "AsyncOperation State Queue", attributes: .concurrent)
 
     /// Non thread-safe state storage, use only with locks
@@ -47,13 +51,6 @@ open class AsyncOperation: Operation {
             didChangeValue(forKey: oldValue.keyPath)
         }
     }
-}
-
-extension AsyncOperation {
-
-    public override var isAsynchronous: Bool { true }
-    public override var isExecuting: Bool { state == .executing }
-    public override var isFinished: Bool { state == .finished }
 
     public override func start() {
 

--- a/Sources/Core/Extensions/FileManager+Extensions.swift
+++ b/Sources/Core/Extensions/FileManager+Extensions.swift
@@ -10,7 +10,7 @@ import Foundation
 public extension FileManager {
 
     static func createTemporaryDirectory() throws -> URL {
-        let uuid = "com.stherold.\(ProcessInfo.processInfo.processName).\(NSUUID().uuidString)"
+        let uuid = "\(ProcessInfo.processId).\(NSUUID().uuidString)"
         let tmpDirectoryURL = FileManager.default.temporaryDirectory.appendingPathComponent(uuid)
         try FileManager.default.createDirectory(at: tmpDirectoryURL, withIntermediateDirectories: true, attributes: nil)
         return tmpDirectoryURL

--- a/Sources/Core/Extensions/ProcessInfo+Extensions.swift
+++ b/Sources/Core/Extensions/ProcessInfo+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  ProcessInfo+Extensions.swift
+//  
+//
+//  Created by Stefan Herold on 17.11.20.
+//
+
+import Foundation
+
+public extension ProcessInfo {
+
+    static var processId: String {
+        "com.stherold.\(processInfo.processName)"
+    }
+}

--- a/Sources/Core/Networking/JSONWebToken.swift
+++ b/Sources/Core/Networking/JSONWebToken.swift
@@ -14,21 +14,7 @@ import FoundationNetworking
 
 public struct JSONWebToken {
 
-    public static func tokenAsc() throws -> String {
-
-        let env = ProcessInfo.processInfo.environment
-
-        guard let keyFile = env["ASC_AUTH_KEY"], !keyFile.isEmpty else {
-            throw Error.environmentVariableNotAvailable("ASC_AUTH_KEY")
-        }
-
-        guard let kid = env["ASC_AUTH_KEY_ID"], !kid.isEmpty else {
-            throw Error.environmentVariableNotAvailable("ASC_AUTH_KEY_ID")
-        }
-
-        guard let iss = env["ASC_AUTH_KEY_ISSUER_ID"], !iss.isEmpty else {
-            throw Error.environmentVariableNotAvailable("ASC_AUTH_KEY_ISSUER_ID")
-        }
+    public static func tokenAsc(keyFile: String, kid: String, iss: String) throws -> String {
 
         let claims = JWTClaimsAsc(iss: iss,
                                   exp: Date(timeIntervalSinceNow: 20 * 60),
@@ -128,7 +114,6 @@ public extension JSONWebToken {
 
     enum Error: Swift.Error {
         case credentialsNotSet
-        case environmentVariableNotAvailable(String)
         case unableToConstructJWT
         case fileNotFound(String)
         case privateKeyInvalid

--- a/Sources/Core/PropertyWrapper/UserDefaults+PropertyWrapper.swift
+++ b/Sources/Core/PropertyWrapper/UserDefaults+PropertyWrapper.swift
@@ -1,0 +1,36 @@
+//
+//  UserDefaults+PropertyWrapper.swift
+//  
+//
+//  Created by Stefan Herold on 17.11.20.
+//
+
+import Foundation
+
+@propertyWrapper
+public struct UserDefault<T: Codable> {
+    let key: String
+    let defaultValue: T
+
+    public init(_ key: String, defaultValue: T) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+
+    public var wrappedValue: T {
+        get {
+            if let data = UserDefaults.standard.object(forKey: key) as? Data,
+               let user = try? JSONDecoder().decode(T.self, from: data) {
+                return user
+
+            }
+
+            return  defaultValue
+        }
+        set {
+            if let encoded = try? JSONEncoder().encode(newValue) {
+                UserDefaults.standard.set(encoded, forKey: key)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes

### Support for multiple teams

The basics of supporting the registration of multiple teams enables us to support multiple teams too. Now, whenever you have more than one key registered, the tool asks you which one you want to use. With this you can operate on multiple teams.

### Implement API key registration (no env variables anymore)

API key parameters (key path, key id, issuer id) are now stored in
user defaults instead of retrieved from the environment.

This enables the registration of one App Store Connect API key for
each of your teams and loosens the rstriction to only one API key.

All ASC commands can now operate on all teams if desired.
Alternatively each command can ask for which team the action
should be performed.

### Usage of operations and operation queues

Subcommand `api-keys` uses operations under the hood wich will also be the new standard in future. Next big step is to remove the huge enum class and create nice little operation classes for each. Implementation of the command pattern is coming 🎉