### PR TITLE
Implement command pattern for asc api-keys

### DIFF
--- a/Sources/ASC/AscResource.swift
+++ b/Sources/ASC/AscResource.swift
@@ -29,7 +29,7 @@ extension AscResource: Resource {
 
         if apiKey == nil {
             let op = ApiKeysOperation(.list)
-            ASC.queue.addOperations([op], waitUntilFinished: true)
+            op.executeSync()
             let apiKeys = try op.result.get()
 
             switch apiKeys.count {

--- a/Sources/ASC/commands/ASC.swift
+++ b/Sources/ASC/commands/ASC.swift
@@ -12,8 +12,6 @@ import Core
 /// The main class for the App Store Connect command line tool.
 public final class ASC: ParsableCommand {
 
-    /// Concurrent operation queue
-    static let queue = OperationQueue()
     /// The API key chosen by the user. If only one key is registered this one is automatically used.
     static var apiKey: ApiKey?
 

--- a/Sources/ASC/commands/sub/ApiKeys.swift
+++ b/Sources/ASC/commands/sub/ApiKeys.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import ArgumentParser
+import Core
 
 extension ASC {
 
@@ -33,7 +34,7 @@ extension ASC.ApiKeys {
 
         func run() throws {
             let op = ApiKeysOperation(.list)
-            ASC.queue.addOperations([op], waitUntilFinished: true)
+            op.executeSync()
             try op.result.get().forEach { print($0) }
         }
     }
@@ -61,9 +62,11 @@ extension ASC.ApiKeys {
 
         func run() throws {
             let key = ApiKey(name: name, path: path, keyId: keyId, issuerId: issuerId)
-            let op = ApiKeysOperation(.register(key: key))
-            ASC.queue.addOperations([op], waitUntilFinished: true)
-            try op.result.get().forEach { print($0) }
+            let ops = [
+                ApiKeysOperation(.register(key: key)),
+                ApiKeysOperation(.list)
+            ]
+            (ops as [Command]).executeSync()
         }
     }
 
@@ -80,9 +83,11 @@ extension ASC.ApiKeys {
         var keyId: String
 
         func run() throws {
-            let op = ApiKeysOperation(.delete(keyId: keyId))
-            ASC.queue.addOperations([op], waitUntilFinished: true)
-            try op.result.get().forEach { print($0) }
+            let ops = [
+                ApiKeysOperation(.delete(keyId: keyId)),
+                ApiKeysOperation(.list)
+            ]
+            (ops as [Command]).executeSync()
         }
     }
 }

--- a/Sources/ASC/service/ApiKeysOperation.swift
+++ b/Sources/ASC/service/ApiKeysOperation.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Core
 
-final class ApiKeysOperation: AsyncOperation {
+final class ApiKeysOperation: AsyncOperation, Command {
 
     enum SubCommand {
         case list

--- a/Sources/Core/Command.swift
+++ b/Sources/Core/Command.swift
@@ -1,0 +1,49 @@
+//
+//  Command.swift
+//  ASC
+//
+//  Created by Stefan Herold on 19.11.20.
+//
+
+import Foundation
+
+/// Concurrent operation queue
+private let serialQueue: OperationQueue = {
+    let queue = OperationQueue()
+    queue.maxConcurrentOperationCount = 1
+    return queue
+}()
+
+/// Contains the general logic for execution of commands.
+///
+/// A command is defined as protocol on top of `Operation` which is important for it's execution which is done using
+/// a OperationQueue.
+public protocol Command: Operation {
+
+}
+
+public extension Operation {
+
+    func executeSync() {
+        serialQueue.addOperations([self], waitUntilFinished: true)
+    }
+
+    func executeAsync(completion: @escaping () -> Void) {
+
+        serialQueue.addOperation(self)
+        serialQueue.addBarrierBlock { completion() }
+    }
+}
+
+public extension Array where Element == Command {
+
+    func executeSync() {
+        serialQueue.addOperations(self, waitUntilFinished: true)
+    }
+
+    func executeAsync(completion: @escaping () -> Void) {
+
+        serialQueue.addOperations(self, waitUntilFinished: false)
+        serialQueue.addBarrierBlock { completion() }
+    }
+}

--- a/Sources/Core/NetworkCommand.swift
+++ b/Sources/Core/NetworkCommand.swift
@@ -1,0 +1,38 @@
+//
+//  NetworkCommand.swift
+//  ASC
+//
+//  Created by Stefan Herold on 19.11.20.
+//
+
+import Foundation
+
+/// Describes everything to operate on network resources. Encapsulates the details to form a network request.
+public protocol NetworkCommand: Command {
+
+    static var service: Service { get }
+    var host: String { get }
+    var port: Int? { get }
+    var path: String { get }
+    var queryItems: [URLQueryItem] { get }
+    var method: HTTPMethod { get }
+    var headers: [String: String]? { get }
+    var parameters: [String: Any]? { get }
+    var shouldAuthorize: Bool { get }
+}
+
+public extension NetworkCommand {
+
+    var url: URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.port = port
+        components.path = path
+
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+        return components.url!
+    }
+}


### PR DESCRIPTION
We can now execute multiple commands after each other and wait for the result:

```swift
let key = ApiKey(name: "Test Key", path: "../dummy/..", keyId: "DUMMY", issuerId: "d.....")
let ops = [
    ApiKeysOperation(.list),
    ApiKeysOperation(.register(key: key)),
    ApiKeysOperation(.list),
    ApiKeysOperation(.delete(keyId: key.keyId)),
    ApiKeysOperation(.list)
]

(ops as [Command]).executeAsync() {
    // executed after all commands are finished
}
```

sync is also possible (usable in command line tools):

```swift
let key = ApiKey(name: "Test Key", path: "../dummy/..", keyId: "DUMMY", issuerId: "d.....")
let ops = [
    ApiKeysOperation(.list),
    ApiKeysOperation(.register(key: key)),
    ApiKeysOperation(.list),
    ApiKeysOperation(.delete(keyId: key.keyId)),
    ApiKeysOperation(.list)
]

(ops as [Command]).executeSync()

for op in ops {
    for key in try! op.result.get() {
        print(key)
    }
    print("---")
}
```

This is the whole async code (for debugging):
```swift
let key = ApiKey(name: "Test Key", path: "../dummy/..", keyId: "DUMMY", issuerId: "d.....")
let ops = [
    ApiKeysOperation(.list),
    ApiKeysOperation(.register(key: key)),
    ApiKeysOperation(.list),
    ApiKeysOperation(.delete(keyId: key.keyId)),
    ApiKeysOperation(.list)
]

(ops as [Command]).executeAsync() {
    for op in ops {
        for key in try! op.result.get() {
            print(key)
        }
        print("---")
    }
}

var results = ops.compactMap { $0.result }

repeat {
    results = ops.compactMap { $0.result }
    RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
} while results.count != ops.count
```