### PR TITLE
Use group name parameter instead of group id's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#25](https://github.com/blackjacx/assist/pull/25): Use group name parameter instead of group id's - [@blackjacx](https://github.com/blackjacx).
 * [#21](https://github.com/blackjacx/assist/pull/21): Implement command pattern for asc api-keys - [@blackjacx](https://github.com/blackjacx).
 
 ## [0.0.3] - 2020-11-19

--- a/Sources/ASC/ASCService.swift
+++ b/Sources/ASC/ASCService.swift
@@ -120,7 +120,7 @@ struct ASCService {
             case let .success(result):
                 receivedObjects.append(result)
                 let betaGroup = betaGroups.filter { id == $0.id }[0]
-                print("Added tester \(result.name) (\(email)) to group \(String(describing: betaGroup.name)) (\(id))")
+                print("Added tester: \(result.name), email: \(email), id: \(result.id) to group: \(betaGroup.name), id: \(id)")
             case let .failure(error): errors.append(error)
             }
         }

--- a/Sources/ASC/ASCService.swift
+++ b/Sources/ASC/ASCService.swift
@@ -130,14 +130,18 @@ struct ASCService {
         }
     }
 
-    static func deleteBetaTester(emails: String, groupIds: [String]) throws {
+    static func deleteBetaTester(emails: [String]) throws {
 
-        guard emails.count > 0 else { throw AscError.noDataProvided("email") }
+        guard !emails.isEmpty else { throw AscError.noDataProvided("emails") }
 
-        let filter = Filter(key: BetaTester.FilterKey.email, value: emails)
-        let foundTesters = try listBetaTester(filters: [filter]) // sync
+        let filter = Filter(key: BetaTester.FilterKey.email, value: emails.joined(separator: ","))
+        let foundTesters = try listBetaTester(filters: [filter])
 
-        guard foundTesters.count > 0 else { return }
+        // Don't throw, just return to print nothing
+        guard !foundTesters.isEmpty else {
+            print("No testers found.")
+            return
+        }
 
         var receivedObjects: [EmptyResponse] = []
         var errors: [Error] = []
@@ -149,7 +153,7 @@ struct ASCService {
             switch result {
             case let .success(result):
                 receivedObjects.append(result)
-                var messages = ["Removed \(tester.name)"]
+                var messages = ["Removed \(tester.name) from all groups."]
                 if let email = tester.attributes.email { messages.append("(\(email))")}
                 print(messages.joined(separator: " "))
             case let .failure(error): errors.append(error)

--- a/Sources/ASC/ASCService.swift
+++ b/Sources/ASC/ASCService.swift
@@ -34,7 +34,7 @@ struct ASCService {
 
         let apps = try listApps()
         let iterableAppIds = appIds.count > 0 ? appIds : apps.map({ $0.id })
-        var functionResult: [(app: App, versions: [AppStoreVersion])] = []
+        var appVersionTuple: [(app: App, versions: [AppStoreVersion])] = []
         var errors: [Error] = []
 
         for id in iterableAppIds {
@@ -44,7 +44,7 @@ struct ASCService {
             switch result {
             case let .success(versions):
                 let app = apps.first(where: { $0.id == id })!
-                functionResult.append((app: app, versions: versions))
+                appVersionTuple.append((app: app, versions: versions))
             case let .failure(error):
                 errors.append(error)
             }
@@ -54,7 +54,7 @@ struct ASCService {
             throw AscError.requestFailed(underlyingErrors: errors)
         }
 
-        return functionResult
+        return appVersionTuple
     }
 
     // MARK: - BetaTester

--- a/Sources/ASC/ASCService.swift
+++ b/Sources/ASC/ASCService.swift
@@ -101,7 +101,7 @@ struct ASCService {
         }
     }
 
-    static func addBetaTester(email: String, first: String, last: String, groupNames: [String]) throws -> [BetaTester] {
+    static func addBetaTester(email: String, first: String, last: String, groupNames: [String]) throws {
 
         let betaGroups: Set<Group> = try groupNames
             // create filters for group names
@@ -128,7 +128,6 @@ struct ASCService {
         if !errors.isEmpty {
             throw AscError.requestFailed(underlyingErrors: errors)
         }
-        return receivedObjects
     }
 
     static func deleteBetaTester(emails: String, groupIds: [String]) throws {

--- a/Sources/ASC/commands/sub/BetaTesters.swift
+++ b/Sources/ASC/commands/sub/BetaTesters.swift
@@ -85,12 +85,8 @@ extension ASC.BetaTesters {
         @Option(name: .shortAndLong, parsing: .upToNextOption, help: "The group names to add the new beta tester to.")
         var groupNames: [String]
 
-        @Argument(help: "The attribute you are interested in. [firstName | lastName | email | attributes] (default: id).")
-        var attribute: String?
-
         func run() throws {
-            let result = try ASCService.addBetaTester(email: email, first: firstName, last: lastName, groupNames: groupNames)
-            result.out(attribute)
+            try ASCService.addBetaTester(email: email, first: firstName, last: lastName, groupNames: groupNames)
         }
     }
 

--- a/Sources/ASC/commands/sub/BetaTesters.swift
+++ b/Sources/ASC/commands/sub/BetaTesters.swift
@@ -82,17 +82,14 @@ extension ASC.BetaTesters {
         @Option(name: .shortAndLong, help: "The email of the user.")
         var email: String
 
-        @Option(name: .shortAndLong, parsing: .upToNextOption, help: "The groups to add the new beta tester to.")
-        var groupIDs: [String]
+        @Option(name: .shortAndLong, parsing: .upToNextOption, help: "The group names to add the new beta tester to.")
+        var groupNames: [String]
 
         @Argument(help: "The attribute you are interested in. [firstName | lastName | email | attributes] (default: id).")
         var attribute: String?
 
         func run() throws {
-            let result = try ASCService.addBetaTester(email: email,
-                                                      first: firstName,
-                                                      last: lastName,
-                                                      groupIDs: groupIDs)
+            let result = try ASCService.addBetaTester(email: email, first: firstName, last: lastName, groupNames: groupNames)
             result.out(attribute)
         }
     }

--- a/Sources/ASC/commands/sub/BetaTesters.swift
+++ b/Sources/ASC/commands/sub/BetaTesters.swift
@@ -100,19 +100,11 @@ extension ASC.BetaTesters {
         @OptionGroup()
         var options: Options
         
-        @Option(name: .shortAndLong, help: "A list of comma-separated emails you of users you want to remove.")
-        var emails: String
-
-        // Code to delete user in specific groups:
-        //  curl -g -s -X DELETE "$url/betaTesters/$uid/relationships/betaGroups" -H  "$json_content_type" -H "Authorization: $ASC_AUTH_HEADER" -d '{"data": [{ "id": "'$gid'", "type": "betaGroups" }] }'
-        @Option(name: .shortAndLong, parsing: .upToNextOption, help: "The groups to add the new beta tester to.")
-        var groupIds: [String] = []
-
-        @Argument(help: "The attribute you are interested in. [firstName | lastName | email | attributes] (default: id).")
-        var attribute: String?
+        @Option(name: .shortAndLong, help: "A list of emails of users you want to remove.")
+        var emails: [String]
 
         func run() throws {
-            try ASCService.deleteBetaTester(emails: emails, groupIds: groupIds)
+            try ASCService.deleteBetaTester(emails: emails)
         }
     }
 }

--- a/Sources/ASC/models/Group.swift
+++ b/Sources/ASC/models/Group.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Group: Codable {
+struct Group: Codable, Hashable, Equatable  {
     var type: String
     var id: String
     var attributes: Attributes
@@ -16,11 +16,11 @@ struct Group: Codable {
 
 extension Group {
 
-    struct Attributes: Codable {
+    struct Attributes: Codable, Hashable, Equatable {
         var name: String
     }
 
-    struct Relationships: Codable {
+    struct Relationships: Codable, Hashable, Equatable {
         var app: Relation
         var builds: Relation
         var betaTesters: Relation

--- a/Sources/ASC/models/Relation.swift
+++ b/Sources/ASC/models/Relation.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-struct Relation: Codable {
+struct Relation: Codable, Hashable, Equatable {
     var links: Links
 }
 
-struct Links: Codable {
+struct Links: Codable, Hashable, Equatable {
     var related: URL
     var `self`: URL
 }


### PR DESCRIPTION
# Changes

### Add beta testers by specifying group name
Now we can simply specify a group name where we want to add the tester. They will be added to all groups matching this name. No additional request on the command line to get the group id's for a necessary anymore. This is done internally now.

The new command is now `asc beta-testers add -e "john@doe.com" -n "John" -l "Doe" -g "group-name"`

This enables now the usage of multiple API keys.

### Specify function result var name
When getting the App Store versions this was not optimally named.

### Improved logging of added tester

### Remove global output when adding beta testers
The command itself does the logging here.

### Remove groupIds from beta group deletion
It was never used, we usually delete testers from all groups.
