### PR TITLE
Adding TestPlan Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#42](https://github.com/blackjacx/assist/pull/42): Adding TestPlan Parameter - [@Blackjacx](https://github.com/blackjacx).
 
 ## [0.1.0] - 2021-11-25Z
 * [#39](https://github.com/blackjacx/assist/pull/39): Establishing Homebrew Support - [@Blackjacx](https://github.com/blackjacx).

--- a/Sources/Core/Simulator/Simctl.swift
+++ b/Sources/Core/Simulator/Simctl.swift
@@ -95,7 +95,13 @@ public extension Simctl {
         }
     }
 
-    static func snap(styles: [Style], workspace: String, schemes: [String], deviceIds: [String], outURL: URL, zipFileName: String) throws {
+    static func snap(styles: [Style],
+                     workspace: String,
+                     schemes: [String],
+                     testPlanName: String?,
+                     deviceIds: [String],
+                     outURL: URL,
+                     zipFileName: String) throws {
 
         for style in styles {
             // The following generates a long log of all devices (Useful on a CI for debugging)
@@ -115,8 +121,8 @@ public extension Simctl {
                 let currentURL = outURL.appendingPathComponent(scheme).appendingPathComponent(style.rawValue)
                 let resultsBundleURL = currentURL.appendingPathComponent("result_bundle.xcresult")
                 let screensURL = currentURL.appendingPathComponent("screens")
-                let testPlanName = "\(scheme)-Screenshots"
 
+                let testPlanName = testPlanName ?? "\(scheme)-Screenshots"
                 Logger.shared.info("Running test plan '\(testPlanName)' for scheme '\(scheme)' and style '\(style)'", inset: 1)
 
                 // This command just needs the binaries and the path to the xctestrun file created before the actual

--- a/Sources/Snap/commands/sub/Run.swift
+++ b/Sources/Snap/commands/sub/Run.swift
@@ -53,6 +53,9 @@ extension Snap {
         @Option(name: [.short, .customLong("scheme")], help: "A scheme to run the screenshot tests on. Can be specified multiple times to generate screenshots for multiple schemes.")
         var schemes: [String]
 
+        @Option(help: "The name of the TestPlan running the screenshot tests.")
+        var testPlanName: String?
+
         @Option(parsing: .upToNextOption, help: "The appearances the screenshots should be made for, e.g. --appearances \(Simctl.Style.allCases.map({"\"\($0.parameterName)\""}).joined(separator: " "))")
         var appearances: [Simctl.Style] = [.light]
 
@@ -133,6 +136,7 @@ extension Snap {
                 try Simctl.snap(styles: appearances,
                                 workspace: workspace,
                                 schemes: schemes,
+                                testPlanName: testPlanName,
                                 deviceIds: deviceIds,
                                 outURL: outURL,
                                 zipFileName: zipFileName)


### PR DESCRIPTION
This adds the possibility to provide a name for the testplan that runs the screenshot tests. This is helpful when the name of this test plan is always the same, e.g. in the case of a multi-target white-label project.