### PR TITLE
Switch to String types when specifying devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#52](https://github.com/blackjacx/assist/pull/52): Switch to String types when specifying devices - [@Blackjacx](https://github.com/blackjacx).
 
 ## [0.3.0] - 2022-09-02Z
 * Upgrade to Swift 5.6 - [@Blackjacx](https://github.com/blackjacx).

--- a/Sources/Core/Shell/Simctl/Simctl.swift
+++ b/Sources/Core/Shell/Simctl/Simctl.swift
@@ -47,13 +47,13 @@ public extension Simctl {
         return devices
     }
 
-    static func deviceIdsFor(deviceTypes: [DeviceType], runtime: Runtime) throws -> [String] {
+    static func deviceIdsFor(deviceNames: [String], runtime: Runtime) throws -> [String] {
         var deviceIDs: [String] = []
 
-        try deviceTypes.forEach { (deviceType) in
-            guard let deviceID = try devicesForRuntime(runtime).first(where: { $0.name == deviceType.simCtlValue }) else {
+        try deviceNames.forEach { (name) in
+            guard let deviceID = try devicesForRuntime(runtime).first(where: { $0.name == name }) else {
                 // Create device if it is not yet available
-                let deviceID = try createDevice(name: deviceType.simCtlValue, id: deviceType.simCtlValue, runtime: runtime)
+                let deviceID = try createDevice(name: name, id: name, runtime: runtime)
                 deviceIDs.append(deviceID)
                 return
             }
@@ -177,85 +177,6 @@ public extension Simctl {
         case dark
 
         public var parameterName: String { rawValue }
-    }
-
-//    "Apple TV 4K (2nd generation)"
-//    "Apple TV 4K (at 1080p) (2nd generation)"
-//    "Apple TV 4K (at 1080p)"
-//    "Apple TV 4K"
-//    "Apple TV"
-//    "Apple Watch SE - 40mm"
-//    "Apple Watch SE - 44mm"
-//    "Apple Watch Series 3 - 38mm"
-//    "Apple Watch Series 3 - 42mm"
-//    "Apple Watch Series 4 - 40mm"
-//    "Apple Watch Series 4 - 44mm"
-//    "Apple Watch Series 5 - 40mm"
-//    "Apple Watch Series 5 - 44mm"
-//    "Apple Watch Series 6 - 40mm"
-//    "Apple Watch Series 6 - 44mm"
-//    "iPad (5th generation)"
-//    "iPad (6th generation)"
-//    "iPad (7th generation)"
-//    "iPad (8th generation)"
-//    "iPad Air (3rd generation)"
-//    "iPad Air (4th generation)"
-//    "iPad Air 2"
-//    "iPad Air"
-//    "iPad Pro (10.5-inch)"
-//    "iPad Pro (11-inch) (1st generation)"
-//    "iPad Pro (11-inch) (2nd generation)"
-//    "iPad Pro (11-inch) (3rd generation)"
-//    "iPad Pro (12.9-inch) (1st generation)"
-//    "iPad Pro (12.9-inch) (2nd generation)"
-//    "iPad Pro (12.9-inch) (3rd generation)"
-//    "iPad Pro (12.9-inch) (4th generation)"
-//    "iPad Pro (12.9-inch) (5th generation)"
-//    "iPad Pro (9.7-inch)"
-//    "iPad mini (5th generation)"
-//    "iPad mini 2"
-//    "iPad mini 3"
-//    "iPad mini 4"
-//    "iPhone 8 Plus"
-//    "iPhone 8"
-
-    enum DeviceType: String, CaseIterable {
-        // DEPRECATED: Use `iPhoneSE2` instead
-        case iPhoneSE
-        case iPhoneSE2
-        case iPhoneSE3
-        case iPhone11
-        case iPhone11Pro
-        case iPhone11ProMax
-        case iPhone12Mini
-        case iPhone12
-        case iPhone12Pro
-        case iPhone12ProMax
-        case iPhone13Mini
-        case iPhone13
-        case iPhone13Pro
-        case iPhone13ProMax
-
-        public var parameterName: String { rawValue }
-
-        public var simCtlValue: String {
-            switch self {
-            case .iPhoneSE: return "iPhone SE (2nd generation)"
-            case .iPhoneSE2: return "iPhone SE (2nd generation)"
-            case .iPhoneSE3: return "iPhone SE (3rd generation)"
-            case .iPhone11: return "iPhone 11"
-            case .iPhone11Pro: return "iPhone 11 Pro"
-            case .iPhone11ProMax: return "iPhone 11 Pro Max"
-            case .iPhone12Mini: return "iPhone 12 mini"
-            case .iPhone12: return "iPhone 12"
-            case .iPhone12Pro: return "iPhone 12 Pro"
-            case .iPhone12ProMax: return "iPhone 12 Pro Max"
-            case .iPhone13Mini: return "iPhone 13 mini"
-            case .iPhone13: return "iPhone 13"
-            case .iPhone13Pro: return "iPhone 13 Pro"
-            case .iPhone13ProMax: return "iPhone 13 Pro Max"
-            }
-        }
     }
 
     /// This enum represents only the latest iOS versions from a major version.

--- a/Sources/Snap/commands/Snap.swift
+++ b/Sources/Snap/commands/Snap.swift
@@ -63,8 +63,8 @@ public final class Snap: ParsableCommand {
     @Option(parsing: .upToNextOption, help: "The appearances the screenshots should be made for, e.g. --appearances \(Simctl.Style.allCases.map({"\"\($0.parameterName)\""}).joined(separator: " "))")
     var appearances: [Simctl.Style] = [.light]
 
-    @Option(parsing: .upToNextOption, help: "Devices you want to generate screenshots for, e.g. --devices \(Simctl.DeviceType.allCases.map({"\"\($0.parameterName)\""}).joined(separator: " "))")
-    var devices: [Simctl.DeviceType] = [.iPhone12Pro]
+    @Option(parsing: .upToNextOption, help: "Devices you want to generate screenshots for (run `xcrun simctl list` to list all possible devices)")
+    var devices: [String] = ["iPhone 14 Pro"]
 
     @Option(help: "The destination directory where the screenshots and the zip archive should be stored.")
     var destinationDir: String?
@@ -116,10 +116,10 @@ public final class Snap: ParsableCommand {
 
             let configMessage = """
                 Using the following config:
-                    styles: \(appearances.map { $0.parameterName })
-                    devices: \(devices.map { $0.parameterName })
+                    styles: \(ListFormatter.localizedString(byJoining: appearances.map { $0.parameterName }))
+                    devices: \(ListFormatter.localizedString(byJoining: devices))
                     platform: \(platform)
-                    schemes: \(schemes)
+                    schemes: \(ListFormatter.localizedString(byJoining: schemes))
                     destination: \(outURL.path.appendPathComponent(zipFileName))
                 """
             Logger.shared.info(configMessage)
@@ -131,7 +131,7 @@ public final class Snap: ParsableCommand {
             Logger.shared.info("Runtime found \(runtime)")
 
             Logger.shared.info("Find IDs of preferred device IDs")
-            let deviceIds = try Simctl.deviceIdsFor(deviceTypes: devices, runtime: runtime)
+            let deviceIds = try Simctl.deviceIdsFor(deviceNames: devices, runtime: runtime)
             Logger.shared.info("Device IDs Found: \(deviceIds)")
 
             Logger.shared.info("Building all requested schemes for testing")
@@ -175,5 +175,4 @@ struct Options: ParsableArguments {
 }
 
 extension Simctl.Style: ExpressibleByArgument {}
-extension Simctl.DeviceType: ExpressibleByArgument {}
 extension Simctl.Platform: ExpressibleByArgument {}


### PR DESCRIPTION
The removes the pain to always add new device types to the enum when Apple releases a new Xcode 😅