### PR TITLE
Remove platforms enum

### DIFF
--- a/Sources/Core/Shell/Simctl/Simctl.swift
+++ b/Sources/Core/Shell/Simctl/Simctl.swift
@@ -179,19 +179,6 @@ public extension Simctl {
         public var parameterName: String { rawValue }
     }
 
-    /// This enum represents only the latest iOS versions from a major version.
-    /// Omit the platform parameter to use the latest available version. This
-    /// enum is updated after a new version comes out.
-    enum Platform: String, CaseIterable {
-        case ios12_4 = "iOS 12.4"
-        case ios13_7 = "iOS 13.6"
-        case ios14_5 = "iOS 14.5"
-        case ios15_0 = "iOS 15.0"
-        case ios16_0 = "iOS 16.0"
-
-        public var parameterName: String { "\(self)" }
-    }
-
     enum DataNetwork: String {
         case wifi
         case three_g = "3g"

--- a/Sources/Core/Shell/Xcodebuild.swift
+++ b/Sources/Core/Shell/Xcodebuild.swift
@@ -31,11 +31,11 @@ public extension Xcodebuild {
             var args = ["xcodebuild", cmd.rawValue, "-workspace", workspace, "-scheme", scheme]
             destinations.forEach { args += ["-destination", $0] }
 
-            if let testPlan = testPlan {
+            if let testPlan {
                 args += ["-testPlan", testPlan]
             }
 
-            if let resultBundleURL = resultsBundleURL {
+            if let resultBundleURL {
                 args += ["-resultBundlePath", resultBundleURL.path]
             }
 

--- a/Sources/Core/Shell/Zip.swift
+++ b/Sources/Core/Shell/Zip.swift
@@ -19,7 +19,7 @@ public extension Zip {
                     outFile,
                     relativeTargetFolder]
 
-        if let excludePattern = excludePattern {
+        if let excludePattern {
             args += ["-x", excludePattern]
         }
 

--- a/Sources/Snap/commands/Snap.swift
+++ b/Sources/Snap/commands/Snap.swift
@@ -105,7 +105,7 @@ public final class Snap: ParsableCommand {
     public func run() throws {
         let outURL: URL
 
-        if let destinationDir = destinationDir {
+        if let destinationDir {
             outURL = URL(fileURLWithPath: destinationDir, isDirectory: true)
         } else {
             outURL = try FileManager.createTemporaryDirectory()

--- a/Sources/Snap/commands/Snap.swift
+++ b/Sources/Snap/commands/Snap.swift
@@ -73,7 +73,7 @@ public final class Snap: ParsableCommand {
     var zipFileName: String
 
     @Option(help: "An optional platform to be used. Omit to use the latest. Currently only iOS is supported.")
-    var platform: Simctl.Platform?
+    var platform: String?
 
     public init() {
         
@@ -88,15 +88,15 @@ public final class Snap: ParsableCommand {
             throw ValidationError("No target specified.")
         }
 
-        if let destinationDir = self.destinationDir {
+        if let destinationDir {
             var isDir: ObjCBool = false
             guard FileManager.default.fileExists(atPath: destinationDir, isDirectory: &isDir), isDir.boolValue else {
                 throw ValidationError("\(destinationDir) does not exist or is no directory.")
             }
         }
 
-        if let platform = self.platform {
-            guard try Simctl.isPlatformValid(platform.rawValue) else {
+        if let platform {
+            guard try Simctl.isPlatformValid(platform) else {
                 throw ValidationError("\(platform) not installed on your system. Run `xcrun simctl list` to find available ones.")
             }
         }
@@ -112,7 +112,7 @@ public final class Snap: ParsableCommand {
         }
 
         do {
-            let platform = try self.platform?.rawValue ?? Simctl.latestAvailableIOS()
+            let platform = try self.platform ?? Simctl.latestAvailableIOS()
 
             let configMessage = """
                 Using the following config:
@@ -175,4 +175,3 @@ struct Options: ParsableArguments {
 }
 
 extension Simctl.Style: ExpressibleByArgument {}
-extension Simctl.Platform: ExpressibleByArgument {}


### PR DESCRIPTION
# Changes

The enum just created unnecessary maintenance effort. With a string
parameter the tool becomes much more flexible.# Changes
Description of your changes.
