### PR TITLE
Fix screenshot generation because of broken TestPlan parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#57](https://github.com/blackjacx/assist/pull/57): Fix screenshot generation because of broken TestPlan parameter - [@Blackjacx](https://github.com/blackjacx).
 * [#55](https://github.com/blackjacx/assist/pull/55): Remove platforms enum - [@Blackjacx](https://github.com/blackjacx).
 * [#53](https://github.com/blackjacx/assist/pull/53): Handle "Shutting Down" simctl status - [@Blackjacx](https://github.com/blackjacx).
 * [#52](https://github.com/blackjacx/assist/pull/52): Switch to String types when specifying devices - [@Blackjacx](https://github.com/blackjacx).

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.8
 import PackageDescription
 
 let package = Package(
     name: "Assist",
 //    platforms: [.macOS(.v10_15), .macCatalyst(.v13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
     platforms: [
-      .macOS(.v12)
+      .macOS(.v13)
 //        .iOS(.v11),
 //        .watchOS(.v5),
 //        .tvOS(.v11)

--- a/Sources/Snap/commands/Snap.swift
+++ b/Sources/Snap/commands/Snap.swift
@@ -105,6 +105,7 @@ public final class Snap: ParsableCommand {
 
     public func run() throws {
         let outURL: URL
+        let derivedDataUrl = try FileManager.createTemporaryDirectory()
 
         if let destinationDir {
             outURL = URL(fileURLWithPath: destinationDir, isDirectory: true)
@@ -136,18 +137,21 @@ public final class Snap: ParsableCommand {
             Logger.shared.info("Device IDs Found: \(deviceIds)")
 
             Logger.shared.info("Building all requested schemes for testing")
-            try Xcodebuild.execute(cmd: .buildForTesting,
-                                   workspace: workspace,
-                                   schemes: schemes,
-                                   deviceIds: deviceIds)
+            try Xcodebuild.execute(subcommand: .buildForTesting(workspace: workspace, schemes: schemes),
+                                   deviceIds: deviceIds,
+                                   derivedDataUrl: derivedDataUrl)
 
-            Logger.shared.info("Taking screenshots for all requested configs")
+            Logger.shared.info("Taking screenshots for all requested configurations")
             try Simctl.snap(styles: appearances,
                             workspace: workspace,
                             schemes: schemes,
+                            derivedDataUrl: derivedDataUrl,
                             testPlanName: testPlanName,
+                            runtime: runtimeName.components(separatedBy: " ").last!, // grab the version number of the provided runtime
+                            arch: "arm64",
+                            platform: "iphonesimulator", // we're always generating on a simulator
                             deviceIds: deviceIds,
-                            outURL: outURL,
+                            outUrl: outURL,
                             zipFileName: zipFileName)
 
             Logger.shared.info("Find your screens in \(outURL.path)")


### PR DESCRIPTION
# Changes
- Increase package Swift version to 5.8
- Increase macOS version to 13
- Use `-xctestrun` parameter instead of `-testplan` since `-testplan` is broken in Xcode 14

Here are the `xcodebuild` commands that actually worked:

```shell
xcrun xcodebuild build-for-testing -workspace /Users/stherold/dev/projects/db/beiwagen-1/Beiwagen.xcworkspace -scheme DBFFM -destination 'platform=iOS Simulator,id=2253C0D7-C198-44AD-A98B-11301FD88F30'

xcrun xcodebuild test-without-building -destination 'platform=iOS Simulator,id=2253C0D7-C198-44AD-A98B-11301FD88F30' -xctestrun /Users/stherold/Library/Developer/Xcode/DerivedData/Beiwagen-ejtxjgvamondbsabaaqpelmwijpv/Build/Products/DBFFM_Screenshots_iphonesimulator16.4-arm64.xctestrun
```

Here is the mint command for snap:
```shell
mint run Blackjacx/Assist@"fix-screenshot-generation" snap \
  --workspace /Users/stherold/dev/projects/db/beiwagen-1/Beiwagen.xcworkspace \
  --scheme "DBFFM" \
  --test-plan-name "Screenshots" \
  --destination-dir $(mktemp -d) \
  --zip-file-name "Screenshots-$(date +"%Y-%m-%dT%H:%M:%S%z").zip" \
  --appearances "light" --devices "iPhone 14 Pro" \
  --runtime "iOS 16.4"
```

# Links
- [Stack Overflow Question dealing with the broken `-testPlan` parameter](https://stackoverflow.com/questions/75979633/xcodebuild-ignores-testplan-when-using-test-without-building/76814985#76814985)
- [Speed up iOS CI using Test Without Building, xctestrun and Fastlane](https://medium.com/xcblog/speed-up-ios-ci-using-test-without-building-xctestrun-and-fastlane-a982b0060676)
- 