### PR TITLE
Fix `xcTestRunFile` Name Generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#58](https://github.com/blackjacx/assist/pull/58): Fix `xcTestRunFile` Name Generation - [@Blackjacx](https://github.com/blackjacx).
 * [#57](https://github.com/blackjacx/assist/pull/57): Fix screenshot generation because of broken TestPlan parameter - [@Blackjacx](https://github.com/blackjacx).
 * [#55](https://github.com/blackjacx/assist/pull/55): Remove platforms enum - [@Blackjacx](https://github.com/blackjacx).
 * [#53](https://github.com/blackjacx/assist/pull/53): Handle "Shutting Down" simctl status - [@Blackjacx](https://github.com/blackjacx).

--- a/Sources/Core/Extensions/ProcessInfo+Extensions.swift
+++ b/Sources/Core/Extensions/ProcessInfo+Extensions.swift
@@ -1,0 +1,33 @@
+//
+//  ProcessInfo+Extensions.swift
+//  Core
+//
+//  Created by Stefan Herold on 14.08.23.
+//
+
+import Foundation
+
+public extension ProcessInfo {
+    /// Returns a `String` representing the machine hardware name or nil if
+    /// there was an error invoking `uname(_:)` or decoding the response.
+    /// Return value is the equivalent to running `$ uname -m` in shell.
+    static var machineHardwareName: String {
+        get throws {
+            var sysinfo = utsname()
+            let code = uname(&sysinfo)
+            guard code == EXIT_SUCCESS else {
+                throw Error.exitWithErrorCode(code)
+            }
+            let data = Data(bytes: &sysinfo.machine, count: Int(_SYS_NAMELEN))
+            guard let identifier = String(bytes: data, encoding: .ascii) else {
+                throw Error.invalidData(data)
+            }
+            return identifier.trimmingCharacters(in: .controlCharacters)
+        }
+    }
+
+    private enum Error: Swift.Error {
+        case exitWithErrorCode(_ code: Int32)
+        case invalidData(_ data: Data)
+    }
+}

--- a/Sources/Core/Shell/Simctl/Simctl.swift
+++ b/Sources/Core/Shell/Simctl/Simctl.swift
@@ -129,14 +129,14 @@ public extension Simctl {
                     throw Error.xcTestResultsFileNotFound(path: xcTestRunFile.path())
                 }
 
-                let messageComponents = [
-                    "style '\(style)'",
-                    "scheme '\(scheme)'",
-                    "runtime: '\(runtime)'",
-                    "platform: '\(platform)'",
-                    "architecture: '\(arch)'"
-                ]
-                Logger.shared.info("Running test plan '\(testPlanName)' for \(ListFormatter.localizedString(byJoining: messageComponents)))", inset: 1)
+                Logger.shared.info("""
+                    Running test plan '\(testPlanName)' for:
+                        style '\(style)'
+                        scheme '\(scheme)'
+                        runtime: '\(runtime)'
+                        platform: '\(platform)'
+                        architecture: '\(arch)'
+                    """, inset: 1)
 
                 // This command just needs the binaries and the path to the
                 // xctestrun file created before the actual testing. Then

--- a/Sources/Snap/commands/Snap.swift
+++ b/Sources/Snap/commands/Snap.swift
@@ -148,7 +148,7 @@ public final class Snap: ParsableCommand {
                             derivedDataUrl: derivedDataUrl,
                             testPlanName: testPlanName,
                             runtime: runtimeName.components(separatedBy: " ").last!, // grab the version number of the provided runtime
-                            arch: "arm64",
+                            arch: ProcessInfo.machineHardwareName,
                             platform: "iphonesimulator", // we're always generating on a simulator
                             deviceIds: deviceIds,
                             outUrl: outURL,


### PR DESCRIPTION
# Changes
Inject correct architecture string of the respective machine, snap 
runs on in the file `xcTestRunFile`.