### PR TITLE
Fix beta tester deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#60](https://github.com/blackjacx/assist/pull/60): Fix beta tester deletion - [@Blackjacx](https://github.com/blackjacx).
 * [#58](https://github.com/blackjacx/assist/pull/58): Fix `xcTestRunFile` Name Generation - [@Blackjacx](https://github.com/blackjacx).
 * [#57](https://github.com/blackjacx/assist/pull/57): Fix screenshot generation because of broken TestPlan parameter - [@Blackjacx](https://github.com/blackjacx).
 * [#55](https://github.com/blackjacx/assist/pull/55): Remove platforms enum - [@Blackjacx](https://github.com/blackjacx).

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/blackjacx/ASCKit",
       "state" : {
-        "revision" : "90e05ac524dd800041af5244342cc2e5a35b5b98",
-        "version" : "0.1.0"
+        "revision" : "2fe329b694f8ea977fc306e6057e9fa90485c43d",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/blackjacx/Engine", from: "0.0.3"),
-        .package(url: "https://github.com/blackjacx/ASCKit", from: "0.1.0"),
+        .package(url: "https://github.com/blackjacx/ASCKit", from: "0.2.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.1.0"),
         .package(url: "https://github.com/kareman/SwiftShell", from: "5.1.0")

--- a/Sources/ASC/commands/sub/BetaTesters.swift
+++ b/Sources/ASC/commands/sub/BetaTesters.swift
@@ -103,25 +103,21 @@ extension ASC.BetaTesters {
         // `ParsableArguments` type.
         @OptionGroup()
         var options: ApiKeyOptions
-        
-        @Option(name: .shortAndLong, help: "A list of emails of users you want to remove.")
-        var emails: [String]
+
+        @Option(name: .shortAndLong, help: "Filter used for searching for the user. See https://developer.apple.com/documentation/appstoreconnectapi/list_beta_testers for possible values.")
+        var filters: [Filter] = []
 
         func run() async throws {
+            let deletedTesters = try await ASCService.deleteBetaTesters(filters: filters)
 
-            var errors: [Error] = []
-
-            for email in emails {
-                do {
-                    let deletedTester = try await ASCService.deleteBetaTester(email: email)
-                    print("Successfully removed \(deletedTester)")
-                } catch {
-                    errors.append(error)
-                }
+            guard !deletedTesters.isEmpty else {
+                print("No testers found…")
+                return
             }
 
-            if !errors.isEmpty {
-                throw AscError.requestFailed(underlyingErrors: errors)
+            print("Successfully removed the following testers:")
+            deletedTesters.forEach {
+                dump($0)
             }
         }
     }

--- a/Sources/Push/PushEndpoint.swift
+++ b/Sources/Push/PushEndpoint.swift
@@ -20,18 +20,18 @@ extension PushEndpoint: Endpoint {
 
     var url: URL? { nil }
     
-    var host: String { 
-      switch self {
+    var host: String {
+        switch self {
         case .pushViaApns(_, let endpoint, _, _, _): return endpoint.host
         case .pushViaFcm: return "fcm.googleapis.com"
-      }
+        }
     }
     
-    var port: Int? { 
-      switch self {
+    var port: Int? {
+        switch self {
         case .pushViaApns: return 443
         case .pushViaFcm: return nil
-      }
+        }
     }
 
     var path: String {
@@ -70,39 +70,47 @@ extension PushEndpoint: Endpoint {
         ]
 
         guard shouldAuthorize else {
-          return headers
+            return headers
         }
 
         switch self {
         case let .pushViaApns(credentials, _, _, topic, _):
-          headers["apns-topic"] = topic
-          headers["apns-push-type"] = "alert"
+            headers["apns-topic"] = topic
+            headers["apns-push-type"] = "alert"
 
-          do {
-              let token = try await JSONWebToken.token(for: .apns(credentials: credentials))
-              headers["Authorization"] = "Bearer \(token)"
-          } catch {
-              print("Error generating token: \(error)")
-          }
+            do {
+                let token = try await JSONWebToken.token(for: .apns(credentials: credentials))
+                headers["Authorization"] = "Bearer \(token)"
+            } catch {
+                print("Error generating token: \(error)")
+            }
 
         case let .pushViaFcm(_, _, credentials):
-          do {
-              let token = try await JSONWebToken.token(for: .fcm(credentials: credentials))
-              headers["Authorization"] = "Bearer \(token)"
-          } catch {
-              print("Error generating token: \(error)")
-          }
+            do {
+                let token = try await JSONWebToken.token(for: .fcm(credentials: credentials))
+                headers["Authorization"] = "Bearer \(token)"
+            } catch {
+                print("Error generating token: \(error)")
+            }
         }
 
         return headers
     }
 
     var parameters: [String : Any]? {
-      switch self {
+        switch self {
         case let .pushViaApns(_, _, _, _, message):
-          return ["aps": ["alert": message]]
+            return ["aps": ["alert": message]]
         case let .pushViaFcm(deviceToken, message, _):
-          return ["message": ["notification": ["title": "Hello FCM", "body": message], "token": deviceToken]]
+            return [
+                "message": [
+                    "notification": [
+                        "title": "Hello FCM",
+                        "body": message
+                    ],
+                    "token": deviceToken
+                ] as [String: Any]
+            ]
         }
     }
 

--- a/Sources/Push/PushEndpoint.swift
+++ b/Sources/Push/PushEndpoint.swift
@@ -56,7 +56,7 @@ extension PushEndpoint: Endpoint {
     }
 
     var timeout: TimeInterval {
-        5
+        30
     }
     
     var shouldAuthorize: Bool {


### PR DESCRIPTION
# Changes

## Fix beta tester deletion

Now all testers are deleted that are found (before only the first one
was deleted). An additional check is implemented which determines if
the user is still in any VALID beta groups. If a user is only in
INVALID beta groups he is treated as deleted. See comment on
`allValidTesterGroups`.

Specifying filters is way more flexible since we can now search beta
testers by email, firstName, lastName, … in one command call. 🚨 Please
use this power with caution though! Specifying just a first name will
delete all testers that share the same first name.

The for loop over all filters (previously over all emails) has been
moved from Assist to ASCKit to keep the command implementation small.

No error is thrown anymore when no testers have been found. The testers
are just not added to `allDeletedTesters` result anymore.

## Upgrade ASCKit to `0.2.0`

## Increased timeout interval to 30s
Before we often ran into timeouts.

## Switch input from `emails` -> `filters`

Specifying filters is way more flexible since we can now search beta
testers by email, firstName, lastName, … in one command call.

The for loop has also been moved into ASCKit to simplify the call site
in `asc`.

Also the command does not end in a failure error code anymore when no
testers have been found.

## Fixed a waning

Heterogeneous collection literal could only be inferred to '[String :
Any]'; add explicit type annotation if this is intentional.