### PR TITLE
Support specifying specific test plan configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#64](https://github.com/blackjacx/assist/pull/64): Support specifying specific test plan configs - [@Blackjacx](https://github.com/blackjacx).
 
 ## [0.4.2] - 2023-08-28Z
 * [#63](https://github.com/blackjacx/assist/pull/63): Add token subcommand to keys - [@Blackjacx](https://github.com/blackjacx).

--- a/Sources/Core/Shell/Simctl/Simctl.swift
+++ b/Sources/Core/Shell/Simctl/Simctl.swift
@@ -96,6 +96,7 @@ public extension Simctl {
                      schemes: [String],
                      derivedDataUrl: URL,
                      testPlanName: String,
+                     testPlanConfigs: [String],
                      runtime: String,
                      arch: String,
                      platform: String,
@@ -130,7 +131,7 @@ public extension Simctl {
                 }
 
                 Logger.shared.info("""
-                    Running test plan '\(testPlanName)' for:
+                    Running test plan '\(testPlanName) (\(testPlanConfigs.isEmpty ? "all configs" : ListFormatter.localizedString(byJoining: testPlanConfigs)))' for:
                         style '\(style)'
                         scheme '\(scheme)'
                         runtime: '\(runtime)'
@@ -144,7 +145,8 @@ public extension Simctl {
                 // needing the source code, i.e. the tests could be performed
                 // on different machines.
                 try Xcodebuild.execute(subcommand: .testWithoutBuilding(xcTestRunFile: xcTestRunFile,
-                                                                        resultsBundleURL: resultsBundleUrl),
+                                                                        resultsBundleURL: resultsBundleUrl,
+                                                                        testPlanConfigs: testPlanConfigs),
                                        deviceIds: deviceIds,
                                        derivedDataUrl: derivedDataUrl)
 

--- a/Sources/Core/Shell/Xcodebuild.swift
+++ b/Sources/Core/Shell/Xcodebuild.swift
@@ -16,7 +16,10 @@ public struct Xcodebuild {
         let destinations = deviceIds
             .map { "platform=iOS Simulator,id=\($0)" }
             .flatMap { ["-destination", $0] }
-        let commonArgs = ["xcodebuild", subcommand.name, "-derivedDataPath", derivedDataUrl.path()] + destinations
+        let commonArgs = [
+            "xcodebuild", subcommand.name,
+            "-derivedDataPath", derivedDataUrl.path()
+        ] + destinations
         let invocations: [Invocation]
 
         switch subcommand {
@@ -25,11 +28,12 @@ public struct Xcodebuild {
                 Invocation(arguments: commonArgs + ["-workspace", workspace, "-scheme", $0])
             }
 
-        case let .testWithoutBuilding(xcTestRunFile, resultsBundleURL):
+        case let .testWithoutBuilding(xcTestRunFile, resultsBundleURL, testPlanConfigs):
             var args = ["-xctestrun", xcTestRunFile.path()]
             if let resultsBundleURL {
                 args += ["-resultBundlePath", resultsBundleURL.path]
             }
+            args += testPlanConfigs.flatMap { ["-only-test-configuration", $0] }
             invocations = [Invocation(arguments: commonArgs + args)]
         }
 
@@ -42,7 +46,7 @@ public struct Xcodebuild {
 
     public enum Subcommand {
         case buildForTesting(workspace: String, schemes: [String])
-        case testWithoutBuilding(xcTestRunFile: URL, resultsBundleURL: URL? = nil)
+        case testWithoutBuilding(xcTestRunFile: URL, resultsBundleURL: URL? = nil, testPlanConfigs: [String] = [])
 
         var name: String {
             switch self {


### PR DESCRIPTION
# Changes
Adding testPlanConfig parameter for specifying any number of test plan configurations. Make sure they match the correct name which is case sensitive.


# Issues
- Resolve #45