### PR TITLE
Using TabularData for AppStoreVersions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#67](https://github.com/blackjacx/assist/pull/67): Using TabularData for AppStoreVersions - [@Blackjacx](https://github.com/blackjacx).
 
 ## [0.5.1] - 2024-03-08Z
 * Fix simctl issue with processing `12:00` as default statusbar time in simulator - [@Blackjacx](https://github.com/blackjacx).

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
# Changes

Print App Store versions using [TabularData](https://developer.apple.com/documentation/tabulardata) framework.

# Links

- https://holyswift.app/crunching-data-with-the-new-apples-tabulardata-framework/
- https://www.swiftjectivec.com/using-the-tabulardata-framework-to-dump-json-or-csv-data-in-swift/