### PR TITLE
Implement output parameter for sub command app-store-versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#70](https://github.com/dbdrive/beiwagen/pull/70): Implement output parameter for sub command app-store-versions - [@blackjacx](https://github.com/blackjacx). 
 
 ## [0.6.0] - 2025-02-17Z
 * [#68](https://github.com/blackjacx/assist/pull/68): Implement Zero-Dependency JWT Generation - [@Blackjacx](https://github.com/blackjacx).

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "0e6d560cac6ff1e5beaa705efc67633cb3d5f60810acc1260526ed05a1465957",
+  "originHash" : "2ab8bf06192503de8d3f99b5212de3cc18d680ab680ac5ce89f040f13422e3fb",
   "pins" : [
     {
       "identity" : "asckit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/blackjacx/ASCKit",
       "state" : {
-        "revision" : "5f4e3501ca1145cec839bfccb7a0b40939057c7a",
-        "version" : "0.3.0"
+        "revision" : "1e0dcb842c6d179566cacdc6869d2d8584b36959",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/blackjacx/Engine", from: "0.1.0"),
 //        .package(path: "../Engine"),
-        .package(url: "https://github.com/blackjacx/ASCKit", from: "0.3.0"),
+        .package(url: "https://github.com/blackjacx/ASCKit", from: "0.4.0"),
 //        .package(path: "../ASCKit"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
         .package(url: "https://github.com/kareman/SwiftShell", from: "5.1.0")

--- a/Sources/ASC/commands/sub/BetaTesters.swift
+++ b/Sources/ASC/commands/sub/BetaTesters.swift
@@ -56,7 +56,7 @@ extension ASC.BetaTesters {
         @OptionGroup()
         var options: ApiKeyOptions
 
-        @Option(name: [.customShort("i", allowingJoined: false), .long], parsing: .upToNextOption, help: "The Apple app ID(s) that uniquely identifiy the app(s) (e.g. -i \"12345678\" \"14324567\").")
+        @Option(name: [.customShort("i", allowingJoined: false), .long], parsing: .upToNextOption, help: "The Apple app ID(s) that uniquely identify the app(s) (e.g. -i \"12345678\" \"14324567\").")
         var appIds: [String] = []
 
         @Option(name: .shortAndLong, help: "The unique email of the tester to send the invite to.")


### PR DESCRIPTION
# Changes

Now you can tell `asc` the output style by spefifying one of the following:

**Output all builds with fill info**
```
-o standard (you can also leave this one out)
```

**Output grouped by version**
```
-o groupedByVersion
```

**Output grouped by state**
```
-o groupedByState
```


> [!note]
> Additionally all missing app store connect states for builds have been added by upgrading [ASCKit](https://github.com/Blackjacx/ASCKit).



# Issues
- Resolve #69

# How To Test
- [ ] …
- [ ] …