### PR TITLE
Fix XCTestRun File Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#71](https://github.com/dbdrive/beiwagen/pull/71): Fix XCTestRun File Detection - [@blackjacx](https://github.com/blackjacx).
 
 ## [0.7.0] - 2025-03-19Z
 * [#70](https://github.com/dbdrive/beiwagen/pull/70): Implement output parameter for sub command app-store-versions - [@blackjacx](https://github.com/blackjacx). 


### PR DESCRIPTION
# Changes

I recognized that the iOS version and the simulator version not always match! E.g. now Xcode shows iOS 18.2 SDK but iPhone 18.3.1 Simulator. That was why xcodebuild uses the 18.2 SDK version in the xctestrun which therefore could not be found.

Now the file is searched based on extension and test-plan name. Fingers crossed that this is more secure. At least the fishy, custom construction of that file name is now gone…

# How To Test
- [ ] …
- [ ] …