### PR TITLE
Generate shell completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
-# macos
+# Claude
+
+.claude/settings.local.json
+
+# macOS
 **/.DS_Store
 **/.env
 **/.envrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- [#88](https://github.com/dbdrive/beiwagen/pull/88): Generate shell completions - [@blackjacx](https://github.com/blackjacx).
+
 ## [0.10.0] - 2025-12-15Z
 
 - [#83](https://github.com/dbdrive/beiwagen/pull/83): Support request output types - [@blackjacx](https://github.com/blackjacx).

--- a/README.md
+++ b/README.md
@@ -73,6 +73,46 @@ cd AppStoreConnect
 swift run asc -h
 ```
 
+## Shell Completions
+
+All tools (`asc`, `snap`, `push`) ship with built-in shell completion support via `swift-argument-parser`. Run `--generate-completion-script` to generate and install a script for your shell.
+
+### Zsh
+
+```shell
+# Native Zsh
+mkdir -p ~/.zsh/completion
+asc --generate-completion-script zsh > ~/.zsh/completion/_asc
+snap --generate-completion-script zsh > ~/.zsh/completion/_snap
+push --generate-completion-script zsh > ~/.zsh/completion/_push
+# Add to ~/.zshrc if not already present:
+# fpath=(~/.zsh/completion $fpath)
+# autoload -U compinit && compinit
+```
+
+```shell
+# oh-my-zsh
+asc --generate-completion-script zsh > ~/.oh-my-zsh/completions/_asc
+snap --generate-completion-script zsh > ~/.oh-my-zsh/completions/_snap
+push --generate-completion-script zsh > ~/.oh-my-zsh/completions/_push
+```
+
+### Bash
+
+```shell
+asc --generate-completion-script bash > /usr/local/etc/bash_completion.d/asc
+snap --generate-completion-script bash > /usr/local/etc/bash_completion.d/snap
+push --generate-completion-script bash > /usr/local/etc/bash_completion.d/push
+```
+
+### Fish
+
+```shell
+asc --generate-completion-script fish > ~/.config/fish/completions/asc.fish
+snap --generate-completion-script fish > ~/.config/fish/completions/snap.fish
+push --generate-completion-script fish > ~/.config/fish/completions/push.fish
+```
+
 ## Documentation ASC (App Store Connect API CLI)
 
 ### Authentication

--- a/Sources/ASC/commands/ASC.swift
+++ b/Sources/ASC/commands/ASC.swift
@@ -65,7 +65,7 @@ struct ApiKeyOptions: ParsableArguments {
     @Option(name: .shortAndLong, help: "The ID of the key to use.")
     var keyId: String?
 
-    @Option(name: .shortAndLong, help: "The ID of the key to use.")
+    @Option(name: .shortAndLong, help: "The ID of the key to use.", completion: .list(["raw", "none"]))
     var outputType: OutputType = .raw
 
     mutating func validate() throws {

--- a/Sources/ASC/commands/sub/AppStoreVersions.swift
+++ b/Sources/ASC/commands/sub/AppStoreVersions.swift
@@ -38,7 +38,7 @@ extension ASC.AppStoreVersions {
         @Option(name: .shortAndLong, parsing: .upToNextOption, help: "The IDs of the apps you want to get the versions from.")
         var appIds: [String] = []
 
-        @Option(name: .shortAndLong, help: "The type of output you would like to see.")
+        @Option(name: .long, help: "The type of output you would like to see.")
         var outputFormat: OutputFormat = .standard
 
         @Option(name: .shortAndLong, help: "Number of resources to return.")

--- a/Sources/Push/commands/Push.swift
+++ b/Sources/Push/commands/Push.swift
@@ -42,7 +42,7 @@ struct Options: ParsableArguments {
     @Option(name: .shortAndLong, help: "The token of the device you want to push to.")
     var deviceToken: String
 
-    @Option(name: .shortAndLong, help: "The ID of the key to use.")
+    @Option(name: .shortAndLong, help: "The ID of the key to use.", completion: .list(["raw", "none"]))
     var outputType: OutputType = .raw
 
     @Option(name: .shortAndLong, help: "The message you want to send.")

--- a/Sources/Snap/commands/Snap.swift
+++ b/Sources/Snap/commands/Snap.swift
@@ -51,7 +51,7 @@ public final class Snap: ParsableCommand {
     @OptionGroup()
     var options: Options
 
-    @Option(help: "The path to the workspace used to make the screenshots.")
+    @Option(help: "The path to the workspace used to make the screenshots.", completion: .file(extensions: ["xcworkspace"]))
     var workspace: String
 
     @Option(name: [.short, .customLong("scheme")], help: "A scheme to run the screenshot tests on. Can be specified multiple times to generate screenshots for multiple schemes.")
@@ -69,7 +69,7 @@ public final class Snap: ParsableCommand {
     @Option(parsing: .upToNextOption, help: "Devices you want to generate screenshots for (run `xcrun simctl list` to list all possible devices)")
     var devices: [String] = ["iPhone 14 Pro"]
 
-    @Option(help: "The destination directory where the screenshots and the zip archive should be stored.")
+    @Option(help: "The destination directory where the screenshots and the zip archive should be stored.", completion: .directory)
     var destinationDir: String?
 
     @Option(help: "The zip file name that should be used.")


### PR DESCRIPTION
# Changes

- feat: add shell completion support for asc, snap, and push
	- Fix -o name conflict in AppStoreVersions.List (outputFormat vs outputType)
	  that was blocking completion script generation entirely for asc
	- Add completion hints: workspace/destinationDir file/dir completions in snap,
	  output-type value list completions in asc and push
	- Document shell completion installation for zsh, bash, and fish in README
- ignore local Claude settings file


# Issues
- Resolve #74
