### PR TITLE
fix(asc): prevent registering a key with a duplicate ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- [#92](https://github.com/Blackjacx/Assist/pull/92): fix(asc): prevent registering a key with a duplicate ID - [@blackjacx](https://github.com/blackjacx).
 - [#91](https://github.com/Blackjacx/Assist/pull/91): feat(core): replace custom Logger with OSLog.Logger - [@blackjacx](https://github.com/blackjacx).
 - [#90](https://github.com/Blackjacx/Assist/pull/90): Add AGENTS.md and CLAUDE.md files - [@blackjacx](https://github.com/blackjacx).
 - [#89](https://github.com/Blackjacx/Assist/pull/89): Fix Snap shell completion - [@blackjacx](https://github.com/blackjacx).

--- a/Sources/ASC/commands/sub/Keys.swift
+++ b/Sources/ASC/commands/sub/Keys.swift
@@ -77,6 +77,12 @@ extension ASC.Keys {
         @Option(name: [.long, .customShort("s")], help: "The id of the key issuer.")
         var issuerId: String
 
+        func validate() throws {
+            guard !ASCService.listApiKeys().contains(where: { $0.id == keyId }) else {
+                throw ValidationError("A key with id '\(keyId)' is already registered.")
+            }
+        }
+
         func run() throws {
             let key = ApiKey(id: keyId, name: name, source: .localFilePath(path: path), issuerId: issuerId)
             let registeredKey = try ASCService.registerApiKey(key: key)


### PR DESCRIPTION
## Summary

- `asc keys register` now rejects a key ID that is already registered
- Validation happens in `validate()` before `run()`, producing a clean `ValidationError` message

## Repro (before fix)

```shell
asc keys register --key-id ABC123 --name "My Key" --path /path/to/key.p8 --issuer-id XYZ
asc keys register --key-id ABC123 --name "My Key" --path /path/to/key.p8 --issuer-id XYZ
# silently added a duplicate — no error
```

## After fix

```shell
asc keys register --key-id ABC123 ...
asc keys register --key-id ABC123 ...
# Error: A key with id 'ABC123' is already registered.
```

## Test plan

- [ ] `asc keys register` with a new ID succeeds
- [ ] `asc keys register` with an already-registered ID exits with a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)