### PR TITLE
fix(asc): validate key file path exists before registering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- [#93](https://github.com/Blackjacx/Assist/pull/93): fix(asc): validate key file path exists before registering - [@blackjacx](https://github.com/blackjacx).
 - [#92](https://github.com/Blackjacx/Assist/pull/92): fix(asc): prevent registering a key with a duplicate ID - [@blackjacx](https://github.com/blackjacx).
 - [#91](https://github.com/Blackjacx/Assist/pull/91): feat(core): replace custom Logger with OSLog.Logger - [@blackjacx](https://github.com/blackjacx).
 - [#90](https://github.com/Blackjacx/Assist/pull/90): Add AGENTS.md and CLAUDE.md files - [@blackjacx](https://github.com/blackjacx).

--- a/Sources/ASC/commands/sub/Keys.swift
+++ b/Sources/ASC/commands/sub/Keys.swift
@@ -81,6 +81,9 @@ extension ASC.Keys {
             guard !ASCService.listApiKeys().contains(where: { $0.id == keyId }) else {
                 throw ValidationError("A key with id '\(keyId)' is already registered.")
             }
+            guard FileManager.default.fileExists(atPath: path) else {
+                throw ValidationError("No file found at '\(path)'.")
+            }
         }
 
         func run() throws {


### PR DESCRIPTION
## Summary

- `asc keys register` now validates that the p8 file at the given `--path` actually exists before registering the key
- Uses `validate()` so the error is reported cleanly before any state is modified

## Repro (before fix)

```shell
asc keys register --key-id ABC123 --name "My Key" --path /nonexistent/key.p8 --issuer-id XYZ
# silently registered with an invalid path
```

## After fix

```shell
asc keys register --key-id ABC123 --name "My Key" --path /nonexistent/key.p8 --issuer-id XYZ
# Error: No file found at '/nonexistent/key.p8'.
```

## Test plan

- [ ] `asc keys register` with a valid path succeeds
- [ ] `asc keys register` with a non-existent path exits with a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)