### PR TITLE
fix(snap): restore working directory via defer to guarantee cleanup on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- [#94](https://github.com/Blackjacx/Assist/pull/94): fix(snap): restore working directory via defer to guarantee cleanup on error - [@blackjacx](https://github.com/blackjacx).
 - [#93](https://github.com/Blackjacx/Assist/pull/93): fix(asc): validate key file path exists before registering - [@blackjacx](https://github.com/blackjacx).
 - [#92](https://github.com/Blackjacx/Assist/pull/92): fix(asc): prevent registering a key with a duplicate ID - [@blackjacx](https://github.com/blackjacx).
 - [#91](https://github.com/Blackjacx/Assist/pull/91): feat(core): replace custom Logger with OSLog.Logger - [@blackjacx](https://github.com/blackjacx).

--- a/Sources/Core/Shell/Simctl/Simctl.swift
+++ b/Sources/Core/Shell/Simctl/Simctl.swift
@@ -194,12 +194,14 @@ public extension Simctl {
             // Switch into folder to prevent storage of absolute paths
             fileManager.changeCurrentDirectoryPath(outUrl.path)
 
+            defer {
+                // Switch back to the original directory
+                fileManager.changeCurrentDirectoryPath(originalDirectoryPath)
+            }
+
             try Zip.zip(outFile: zipFileName,
                         relativeTargetFolder: scheme,
                         excludePattern: "*.xcresult*")
-
-            // Switch back to the original directory
-            fileManager.changeCurrentDirectoryPath(originalDirectoryPath)
         }
     }
 }


### PR DESCRIPTION
## Summary

- `fileManager.changeCurrentDirectoryPath()` mutates the global process working directory
- Previously, if `Zip.zip` threw an error, the directory was never restored, leaving the process in an unexpected state and causing subsequent operations to fail
- Fix: use `defer` to guarantee the directory is always restored regardless of whether an error is thrown

## Test plan

- [ ] Build succeeds: `swift build`
- [ ] `snap run` completes successfully
- [ ] If `Zip.zip` fails mid-loop, subsequent schemes are not affected by a stale working directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)