### PR TITLE
test(asc): add tests for BetaTesters.List command argument parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- [#96](https://github.com/Blackjacx/Assist/pull/96): test(asc): add tests for BetaTesters.List command argument parsing - [@blackjacx](https://github.com/blackjacx).
 - [#95](https://github.com/Blackjacx/Assist/pull/95): fix(core): remove force unwrap when constructing FCM token URL - [@blackjacx](https://github.com/blackjacx).
 - [#94](https://github.com/Blackjacx/Assist/pull/94): fix(snap): restore working directory via defer to guarantee cleanup on error - [@blackjacx](https://github.com/blackjacx).
 - [#93](https://github.com/Blackjacx/Assist/pull/93): fix(asc): validate key file path exists before registering - [@blackjacx](https://github.com/blackjacx).

--- a/Tests/ASCTests/BetaTesterListTests.swift
+++ b/Tests/ASCTests/BetaTesterListTests.swift
@@ -1,0 +1,90 @@
+//
+//  BetaTesterListTests.swift
+//  ASCTests
+//
+
+import Testing
+@testable import ASC
+
+@Suite("ASC.BetaTesters.List")
+struct BetaTesterListTests {
+
+    @Test("Has correct abstract")
+    func commandAbstract() {
+        #expect(
+            ASC.BetaTesters.List.configuration.abstract ==
+            "Find and list beta testers for all apps, builds, and beta groups."
+        )
+    }
+
+    @Test("Defaults: filters is empty, limit is nil, outputType is raw")
+    func defaultValues() throws {
+        let command = try ASC.BetaTesters.List.parse([])
+        #expect(command.filters.isEmpty)
+        #expect(command.limit == nil)
+        #expect(command.options.outputType == .raw)
+    }
+
+    @Test("--limit sets limit")
+    func parseLimit() throws {
+        let command = try ASC.BetaTesters.List.parse(["--limit", "25"])
+        #expect(command.limit == 25)
+    }
+
+    @Test("-l sets limit")
+    func parseLimitShort() throws {
+        let command = try ASC.BetaTesters.List.parse(["-l", "25"])
+        #expect(command.limit == 25)
+    }
+
+    @Test("--filters parses key=value")
+    func parseSingleFilter() throws {
+        let command = try ASC.BetaTesters.List.parse(["--filters", "email=test@example.com"])
+        #expect(command.filters.count == 1)
+        #expect(command.filters[0].key == AnyHashable("email"))
+        #expect(command.filters[0].value == "test@example.com")
+    }
+
+    @Test("-f parses key=value")
+    func parseSingleFilterShort() throws {
+        let command = try ASC.BetaTesters.List.parse(["-f", "email=test@example.com"])
+        #expect(command.filters.count == 1)
+        #expect(command.filters[0].key == AnyHashable("email"))
+        #expect(command.filters[0].value == "test@example.com")
+    }
+
+    @Test("Multiple --filters flags accumulate")
+    func parseMultipleFilters() throws {
+        let command = try ASC.BetaTesters.List.parse([
+            "--filters", "email=test@example.com",
+            "--filters", "firstName=John",
+        ])
+        #expect(command.filters.count == 2)
+        #expect(command.filters[0].key == AnyHashable("email"))
+        #expect(command.filters[1].key == AnyHashable("firstName"))
+    }
+
+    @Test("Invalid filter (missing =) throws a parse error")
+    func parseInvalidFilter() {
+        #expect(throws: (any Error).self) {
+            try ASC.BetaTesters.List.parse(["-f", "invalidsyntax"])
+        }
+    }
+
+    @Test("--output-type none is parsed correctly")
+    func parseOutputTypeNone() throws {
+        let command = try ASC.BetaTesters.List.parse(["--output-type", "none"])
+        #expect(command.options.outputType == .none)
+    }
+
+    @Test("Combining limit and filter")
+    func parseLimitAndFilter() throws {
+        let command = try ASC.BetaTesters.List.parse([
+            "--limit", "50",
+            "--filters", "email=user@example.com",
+        ])
+        #expect(command.limit == 50)
+        #expect(command.filters.count == 1)
+        #expect(command.filters[0].value == "user@example.com")
+    }
+}


### PR DESCRIPTION
## Summary

Adds 10 tests for `ASC.BetaTesters.List` covering argument parsing using Swift Testing and ArgumentParser's `parse(_:)` API:

- Default values (`filters` empty, `limit` nil, `outputType` raw)
- `--limit` / `-l` parsing
- `--filters` / `-f` single filter parsing (`key=value`)
- Multiple `--filters` flags accumulate into array
- `--output-type none` parsing
- Combined `--limit` and `--filters`
- Invalid filter syntax (missing `=`) throws a parse error

## Test plan

- [ ] `swift test --filter BetaTesterListTests` — all 10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)