### PR TITLE
refactor(asc): simplify Filter argument parsing by removing redundant guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- [#96](https://github.com/Blackjacx/Assist/pull/96): refactor(asc): simplify Filter argument parsing by removing redundant guards - [@blackjacx](https://github.com/blackjacx).
 - [#95](https://github.com/Blackjacx/Assist/pull/95): fix(core): remove force unwrap when constructing FCM token URL - [@blackjacx](https://github.com/blackjacx).
 - [#94](https://github.com/Blackjacx/Assist/pull/94): fix(snap): restore working directory via defer to guarantee cleanup on error - [@blackjacx](https://github.com/blackjacx).
 - [#93](https://github.com/Blackjacx/Assist/pull/93): fix(asc): validate key file path exists before registering - [@blackjacx](https://github.com/blackjacx).

--- a/Sources/ASC/Filter+Extensions.swift
+++ b/Sources/ASC/Filter+Extensions.swift
@@ -14,8 +14,6 @@ extension Filter: ExpressibleByArgument {
     public init?(argument: String) {
         let splitted = argument.split(separator: "=")
         guard splitted.count == 2 else { return nil }
-        guard let key = splitted.first else { return nil }
-        guard let value = splitted.last else { return nil }
-        self = Filter(key: String(key), value: String(value))
+        self = Filter(key: String(splitted[0]), value: String(splitted[1]))
     }
 }


### PR DESCRIPTION
## Summary

- After `guard splitted.count == 2`, accessing `.first` and `.last` is guaranteed to succeed — the guard lets were dead code
- Replace with direct index access `splitted[0]` and `splitted[1]`

## Test plan

- [ ] Build succeeds: `swift build`
- [ ] `--filters email=test@example.com` still parses correctly
- [ ] Invalid filter (missing `=`) still returns nil