### PR TITLE
refactor(core): remove redundant delegate: nil parameter from URLSession data call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- [#98](https://github.com/Blackjacx/Assist/pull/98): refactor(core): remove redundant delegate: nil parameter from URLSession data call - [@blackjacx](https://github.com/blackjacx).
 - [#96](https://github.com/Blackjacx/Assist/pull/96): refactor(asc): simplify Filter argument parsing by removing redundant guards - [@blackjacx](https://github.com/blackjacx).
 - [#95](https://github.com/Blackjacx/Assist/pull/95): fix(core): remove force unwrap when constructing FCM token URL - [@blackjacx](https://github.com/blackjacx).
 - [#94](https://github.com/Blackjacx/Assist/pull/94): fix(snap): restore working directory via defer to guarantee cleanup on error - [@blackjacx](https://github.com/blackjacx).

--- a/Sources/Core/Networking/JSONWebToken.swift
+++ b/Sources/Core/Networking/JSONWebToken.swift
@@ -62,7 +62,7 @@ public enum JSONWebToken {
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         let session = URLSession(configuration: .default)
-        let (data, response) = try await session.data(for: urlRequest, delegate: nil)
+        let (data, response) = try await session.data(for: urlRequest)
 
         guard let httpResponse = response as? HTTPURLResponse, (200...399).contains(httpResponse.statusCode) else {
             throw JWT.Error.invalidResonse(response: response)


### PR DESCRIPTION
## Summary

- `session.data(for:delegate:)` was called with `delegate: nil` which is the default — removed the explicit parameter

## Test plan

- [ ] Build succeeds: `swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)