### PR TITLE
fix(snap): prevent crash on unknown simulator device state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- [#99](https://github.com/Blackjacx/Assist/pull/99): fix(snap): prevent crash on unknown simulator device state - [@blackjacx](https://github.com/blackjacx).
 - [#98](https://github.com/Blackjacx/Assist/pull/98): refactor(core): remove redundant delegate: nil parameter from URLSession data call - [@blackjacx](https://github.com/blackjacx).
 - [#96](https://github.com/Blackjacx/Assist/pull/96): refactor(asc): simplify Filter argument parsing by removing redundant guards - [@blackjacx](https://github.com/blackjacx).
 - [#95](https://github.com/Blackjacx/Assist/pull/95): fix(core): remove force unwrap when constructing FCM token URL - [@blackjacx](https://github.com/blackjacx).

--- a/Sources/Core/Shell/Simctl/Device.swift
+++ b/Sources/Core/Shell/Simctl/Device.swift
@@ -17,9 +17,31 @@ public struct Device: Codable {
 
 public extension Device {
 
-    enum State: String, Codable {
-        case booted = "Booted"
-        case shuttingDown = "Shutting Down"
-        case shutdown = "Shutdown"
+    enum State: Codable {
+        case booted
+        case shuttingDown
+        case shutdown
+        case unknown(String)
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            switch raw {
+            case "Booted": self = .booted
+            case "Shutting Down": self = .shuttingDown
+            case "Shutdown": self = .shutdown
+            default: self = .unknown(raw)
+            }
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .booted: try container.encode("Booted")
+            case .shuttingDown: try container.encode("Shutting Down")
+            case .shutdown: try container.encode("Shutdown")
+            case .unknown(let raw): try container.encode(raw)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #38

The crash was caused by `xcrun simctl list --json` returning a device `state` value (e.g. `"Shutting Down"`, `"Creating"`, `"Booting"`) that the `Device.State` enum couldn't decode. While `"Shutting Down"` was patched previously, any other undocumented state would still crash with:

```
dataCorrupted: Cannot initialize State from invalid String value <state>
```

**Fix:** Replace the `RawRepresentable` string enum with a custom `Codable` implementation that decodes known states explicitly and falls back to `unknown(String)` for anything else — making the decoder resilient to any future simulator states Apple may introduce.

## Test plan

- [ ] Build succeeds: `swift build`
- [ ] `snap run` no longer crashes when a simulator is in an unexpected state

🤖 Generated with [Claude Code](https://claude.com/claude-code)