### PR TITLE
refactor(snap): remove redundant CodingKeys raw values in Runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- [#100](https://github.com/Blackjacx/Assist/pull/100): refactor(snap): remove redundant CodingKeys raw values in Runtime - [@blackjacx](https://github.com/blackjacx).
 - [#98](https://github.com/Blackjacx/Assist/pull/98): refactor(core): remove redundant delegate: nil parameter from URLSession data call - [@blackjacx](https://github.com/blackjacx).
 - [#96](https://github.com/Blackjacx/Assist/pull/96): refactor(asc): simplify Filter argument parsing by removing redundant guards - [@blackjacx](https://github.com/blackjacx).
 - [#95](https://github.com/Blackjacx/Assist/pull/95): fix(core): remove force unwrap when constructing FCM token URL - [@blackjacx](https://github.com/blackjacx).

--- a/Sources/Core/Shell/Simctl/Runtime.swift
+++ b/Sources/Core/Shell/Simctl/Runtime.swift
@@ -11,13 +11,12 @@ public struct Runtime: Codable, CustomStringConvertible {
 
     public var description: String { "ID: \(identifier), Name: \(name)" }
 
-
     enum CodingKeys: String, CodingKey {
         case buildVersion = "buildversion"
-        case identifier = "identifier"
-        case version = "version"
-        case isAvailable = "isAvailable"
-        case name = "name"
+        case identifier
+        case version
+        case isAvailable
+        case name
     }
 
     public var buildVersion: String


### PR DESCRIPTION
## Summary

- `CodingKeys` cases where the raw string value matches the property name exactly are redundant — Swift infers them automatically
- Only `buildVersion = "buildversion"` needs an explicit value since the JSON key differs in casing

## Test plan

- [ ] Build succeeds: `swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)