### PR TITLE
Print keys subcommands as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- [#106](https://github.com/Blackjacx/Assist/pull/106): Print keys subcommands as JSON - [@blackjacx](https://github.com/blackjacx).
 
 ## [0.11.0] - 2026-07-21Z
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "27870c0eaff60bb75b7c1ec9c86c1c8bbefb3a26e6991ab96995c49d809ccc39",
+  "originHash" : "0dd9e05b86d2ede7effc54f4ab4986820a303290e49cee58ad77623ce86b358c",
   "pins" : [
     {
       "identity" : "asckit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/blackjacx/ASCKit",
       "state" : {
-        "revision" : "df449f90fc8acc1e2714594453d508bf4c592ac6",
-        "version" : "0.7.3"
+        "revision" : "e8d609513e6bb58253e77d75da8b31df766270df",
+        "version" : "0.7.4"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/blackjacx/Engine",
       "state" : {
-        "revision" : "d6c7703c3774475ac282842ddb0bf8b67d0eb387",
-        "version" : "0.3.2"
+        "revision" : "3b56381a0821d2d9995957e437e4823e362af1f4",
+        "version" : "0.3.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,10 @@ let package = Package(
         .executable(name: "playground", targets: ["Playground"])
     ],
     dependencies: [
-        .package(url: "https://github.com/blackjacx/Engine", from: "0.3.1"),
-        // .package(path: "../Engine"),
+        .package(url: "https://github.com/blackjacx/Engine", from: "0.3.3"),
+//         .package(path: "../Engine"),
 
-        .package(url: "https://github.com/blackjacx/ASCKit", from: "0.7.3"),
+        .package(url: "https://github.com/blackjacx/ASCKit", from: "0.7.4"),
 //         .package(url: "https://github.com/blackjacx/ASCKit", branch: "develop"),
 //         .package(path: "../ASCKit"),
 

--- a/Sources/ASC/commands/sub/Keys.swift
+++ b/Sources/ASC/commands/sub/Keys.swift
@@ -38,7 +38,7 @@ extension ASC.Keys {
         var options: Options
 
         func run() throws {
-            ASCService.listApiKeys().forEach { print($0) }
+            print(try ASCService.listApiKeys().jsonString())
         }
     }
 
@@ -54,7 +54,7 @@ extension ASC.Keys {
 
         func run() throws {
             let activatedKey = try ASCService.activateApiKey(id: keyId)
-            print(activatedKey)
+            print(try activatedKey.jsonString())
         }
     }
 
@@ -89,7 +89,7 @@ extension ASC.Keys {
         func run() throws {
             let key = ApiKey(id: keyId, name: name, source: .localFilePath(path: path), issuerId: issuerId)
             let registeredKey = try ASCService.registerApiKey(key: key)
-            print(registeredKey)
+            print(try registeredKey.jsonString())
         }
     }
 
@@ -105,7 +105,7 @@ extension ASC.Keys {
 
         func run() throws {
             let deletedKey = try ASCService.deleteApiKey(id: keyId)
-            print(deletedKey)
+            print(try deletedKey.jsonString())
         }
     }
 


### PR DESCRIPTION
# Changes
The `Keys` subcommands printed Swift struct descriptions, which are not machine readable. List, activate, register and delete now emit pretty printed JSON via the shared `jsonString()` helper in Engine.

The token subcommand keeps printing the bare JWT so it stays pipeable into e.g. curl Authorization headers.
